### PR TITLE
Content factory: daily post generator

### DIFF
--- a/content/queue.json
+++ b/content/queue.json
@@ -1,0 +1,16 @@
+[
+  {
+    "slug": "quotes-for-starting-a-new-job",
+    "title": "Motivational Quotes for Starting a New Job",
+    "description": "A curated set of motivational quotes for your first day, plus a few practical mindset tips.",
+    "keywords": ["new job quotes", "first day of work", "motivation"],
+    "category": "quotes"
+  },
+  {
+    "slug": "quotes-for-burnout-recovery",
+    "title": "Motivational Quotes for Burnout Recovery",
+    "description": "Motivational quotes to reset your mindset and recover from burnout, plus small next steps.",
+    "keywords": ["burnout quotes", "recovery", "motivation"],
+    "category": "quotes"
+  }
+]

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{{TITLE}} | Motivational Quote</title>
+  <meta name="description" content="{{DESCRIPTION}}" />
+  <link rel="canonical" href="https://motivational-quote.org/{{SLUG}}.html" />
+
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="{{TITLE}}" />
+  <meta property="og:description" content="{{DESCRIPTION}}" />
+  <meta property="og:url" content="https://motivational-quote.org/{{SLUG}}.html" />
+  <meta name="twitter:card" content="summary" />
+
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6175161566333696" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <div class="container">
+      <h1>{{TITLE}}</h1>
+      <p class="subtitle">{{DESCRIPTION}}</p>
+      <p class="meta">Updated: {{DATE}}</p>
+      <p><a href="/index.html">Home</a> · <a href="/blog.html">Blog</a></p>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="card">
+      <h2>Quotes</h2>
+      <ul>
+        {{QUOTES}}
+      </ul>
+
+      <h2>Small next steps</h2>
+      <ol>
+        <li>Pick one quote that feels true today.</li>
+        <li>Write one action you can do in 10 minutes.</li>
+        <li>Do it, then come back tomorrow.</li>
+      </ol>
+    </section>
+  </main>
+
+  <footer class="container">
+    <p>© {{YEAR}} motivational-quote.org · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a> · <a href="/contact.html">Contact</a></p>
+  </footer>
+</body>
+</html>

--- a/tools/generate-daily.js
+++ b/tools/generate-daily.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const QUEUE = path.join(ROOT, 'content', 'queue.json');
+const TEMPLATE = path.join(ROOT, 'templates', 'post.html');
+const SITEMAP = path.join(ROOT, 'sitemap.xml');
+
+function loadJson(p){ return JSON.parse(fs.readFileSync(p,'utf8')); }
+function saveJson(p,v){ fs.writeFileSync(p, JSON.stringify(v,null,2)+'\n'); }
+
+function escapeHtml(s){
+  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
+function render(tpl, vars){
+  return tpl
+    .replaceAll('{{TITLE}}', vars.title)
+    .replaceAll('{{DESCRIPTION}}', vars.description)
+    .replaceAll('{{SLUG}}', vars.slug)
+    .replaceAll('{{DATE}}', vars.date)
+    .replaceAll('{{YEAR}}', String(vars.year))
+    .replaceAll('{{QUOTES}}', vars.quotesHtml);
+}
+
+function addToSitemap(slug){
+  const url = `https://motivational-quote.org/${slug}.html`;
+  let xml = fs.readFileSync(SITEMAP, 'utf8');
+  if (xml.includes(url)) return;
+  const insert = `  <url>\n    <loc>${url}</loc>\n  </url>\n`;
+  xml = xml.replace(/<\/urlset>\s*$/i, insert + '</urlset>\n');
+  fs.writeFileSync(SITEMAP, xml);
+}
+
+function main(){
+  const queue = loadJson(QUEUE);
+  if (!Array.isArray(queue) || queue.length === 0) {
+    console.error('Queue empty:', QUEUE);
+    process.exit(1);
+  }
+  const item = queue.shift();
+  const slug = item.slug;
+  const outPath = path.join(ROOT, `${slug}.html`);
+  if (fs.existsSync(outPath)) {
+    console.error('Post already exists:', outPath);
+    process.exit(2);
+  }
+
+  // Lightweight quote list (can be expanded later)
+  const quotes = [
+    'One step at a time still counts.',
+    'You don\'t need confidence to start; you need a start.',
+    'Small progress beats perfect plans.',
+    'Do the next right thing.',
+    'Consistency is a superpower.'
+  ];
+  const quotesHtml = quotes.map(q => `<li>${escapeHtml(q)}</li>`).join('\n        ');
+
+  const tpl = fs.readFileSync(TEMPLATE, 'utf8');
+  const now = new Date();
+  const vars = {
+    title: item.title,
+    description: item.description,
+    slug,
+    date: now.toISOString().slice(0,10),
+    year: now.getUTCFullYear(),
+    quotesHtml,
+  };
+  fs.writeFileSync(outPath, render(tpl, vars));
+  saveJson(QUEUE, queue);
+  addToSitemap(slug);
+  console.log('Generated', outPath);
+}
+
+main();


### PR DESCRIPTION
Adds a simple daily publishing pipeline:\n\n- content/queue.json with planned posts\n- templates/post.html\n- tools/generate-daily.js which generates one new post page and updates sitemap.xml\n\nAfter merge, we can schedule a 2am PT cron job to open a PR daily.