### PR TITLE
Add affiliate callouts to relevant posts

### DIFF
--- a/benefits-of-journaling.html
+++ b/benefits-of-journaling.html
@@ -52,6 +52,13 @@
         There’s no perfect format. Use lists or paragraphs, morning pages or evening reviews.
         What matters is regular reflection and honest answers.
       </p>
+      <div class="affiliate-callout" style="background:#fffbeb;border:1px solid #fcd34d;border-radius:8px;padding:16px;margin:24px 0;">
+        <p style="font-weight:600;margin:0 0 8px;">Recommended reading:</p>
+        <ul style="margin:0;padding-left:20px;">
+          <li><a href="https://www.amazon.com/Atomic-Habits-James-Clear/dp/0735211299?tag=motivationalq-20" target="_blank" rel="noopener noreferrer sponsored">Atomic Habits by James Clear</a></li>
+          <li><a href="https://www.amazon.com/Power-Now-Guide-Spiritual-Enlightenment/dp/1577314808?tag=motivationalq-20" target="_blank" rel="noopener noreferrer sponsored">The Power of Now by Eckhart Tolle</a></li>
+        </ul>
+      </div>
     </section>
   </main>
 

--- a/building-self-discipline.html
+++ b/building-self-discipline.html
@@ -52,6 +52,13 @@
         <strong>Pair discipline with rest.</strong> Recovery protects consistency. Sleep, nutrition,
         and short breaks keep your attention sharp and your willpower available.
       </p>
+      <div class="affiliate-callout" style="background:#fffbeb;border:1px solid #fcd34d;border-radius:8px;padding:16px;margin:24px 0;">
+        <p style="font-weight:600;margin:0 0 8px;">Recommended reading:</p>
+        <ul style="margin:0;padding-left:20px;">
+          <li><a href="https://www.amazon.com/Atomic-Habits-James-Clear/dp/0735211299?tag=motivationalq-20" target="_blank" rel="noopener noreferrer sponsored">Atomic Habits by James Clear</a></li>
+          <li><a href="https://www.amazon.com/Power-Now-Guide-Spiritual-Enlightenment/dp/1577314808?tag=motivationalq-20" target="_blank" rel="noopener noreferrer sponsored">The Power of Now by Eckhart Tolle</a></li>
+        </ul>
+      </div>
     </section>
   </main>
 

--- a/importance-of-rest-recovery.html
+++ b/importance-of-rest-recovery.html
@@ -51,6 +51,13 @@
       <p>
         Treat recovery like any other priority—scheduled, deliberate, and guilt-free. You’ll feel better and get more done.
       </p>
+      <div class="affiliate-callout" style="background:#f0fdf4;border:1px solid #86efac;border-radius:8px;padding:16px;margin:24px 0;">
+        <p style="font-weight:600;margin:0 0 8px;">Deepen your practice:</p>
+        <ul style="margin:0;padding-left:20px;">
+          <li><a href="https://www.headspace.com/?utm_source=motivational-quote" target="_blank" rel="noopener noreferrer sponsored">Headspace</a> — Guided meditation for beginners and beyond</li>
+          <li><a href="https://www.calm.com/?utm_source=motivational-quote" target="_blank" rel="noopener noreferrer sponsored">Calm</a> — Sleep stories, meditation, and breathing exercises</li>
+        </ul>
+      </div>
     </section>
   </main>
 

--- a/mindfulness-for-personal-growth.html
+++ b/mindfulness-for-personal-growth.html
@@ -52,6 +52,13 @@
       <p>
         Over time, small practices reduce stress and sharpen attention—making growth feel more doable.
       </p>
+      <div class="affiliate-callout" style="background:#f0fdf4;border:1px solid #86efac;border-radius:8px;padding:16px;margin:24px 0;">
+        <p style="font-weight:600;margin:0 0 8px;">Deepen your practice:</p>
+        <ul style="margin:0;padding-left:20px;">
+          <li><a href="https://www.headspace.com/?utm_source=motivational-quote" target="_blank" rel="noopener noreferrer sponsored">Headspace</a> — Guided meditation for beginners and beyond</li>
+          <li><a href="https://www.calm.com/?utm_source=motivational-quote" target="_blank" rel="noopener noreferrer sponsored">Calm</a> — Sleep stories, meditation, and breathing exercises</li>
+        </ul>
+      </div>
     </section>
   </main>
 

--- a/power-of-habits.html
+++ b/power-of-habits.html
@@ -51,6 +51,13 @@
       <p>
         Review weekly: keep what works, adjust what doesn’t, and add one tiny improvement at a time.
       </p>
+      <div class="affiliate-callout" style="background:#fffbeb;border:1px solid #fcd34d;border-radius:8px;padding:16px;margin:24px 0;">
+        <p style="font-weight:600;margin:0 0 8px;">Recommended reading:</p>
+        <ul style="margin:0;padding-left:20px;">
+          <li><a href="https://www.amazon.com/Atomic-Habits-James-Clear/dp/0735211299?tag=motivationalq-20" target="_blank" rel="noopener noreferrer sponsored">Atomic Habits by James Clear</a></li>
+          <li><a href="https://www.amazon.com/Power-Now-Guide-Spiritual-Enlightenment/dp/1577314808?tag=motivationalq-20" target="_blank" rel="noopener noreferrer sponsored">The Power of Now by Eckhart Tolle</a></li>
+        </ul>
+      </div>
     </section>
   </main>
 

--- a/setting-boundaries-self-care.html
+++ b/setting-boundaries-self-care.html
@@ -53,6 +53,13 @@
         <strong>Review and adjust.</strong> Boundaries change with seasons. Reassess monthly and refine
         anything that isn’t serving you.
       </p>
+      <div class="affiliate-callout" style="background:#f0fdf4;border:1px solid #86efac;border-radius:8px;padding:16px;margin:24px 0;">
+        <p style="font-weight:600;margin:0 0 8px;">Deepen your practice:</p>
+        <ul style="margin:0;padding-left:20px;">
+          <li><a href="https://www.headspace.com/?utm_source=motivational-quote" target="_blank" rel="noopener noreferrer sponsored">Headspace</a> — Guided meditation for beginners and beyond</li>
+          <li><a href="https://www.calm.com/?utm_source=motivational-quote" target="_blank" rel="noopener noreferrer sponsored">Calm</a> — Sleep stories, meditation, and breathing exercises</li>
+        </ul>
+      </div>
     </section>
   </main>
 


### PR DESCRIPTION
Closes #9

## What changed
Added the requested Headspace/Calm affiliate callout block near the bottom of three mindfulness and mental wellness posts. Added the requested Amazon recommended-reading affiliate callout block near the bottom of three self-improvement and personal-growth posts. No files outside the selected root-level HTML articles were changed.

## Files changed
- mindfulness-for-personal-growth.html — added Headspace/Calm affiliate callout
- importance-of-rest-recovery.html — added Headspace/Calm affiliate callout
- setting-boundaries-self-care.html — added Headspace/Calm affiliate callout
- benefits-of-journaling.html — added Amazon recommended-reading affiliate callout
- building-self-discipline.html — added Amazon recommended-reading affiliate callout
- power-of-habits.html — added Amazon recommended-reading affiliate callout

## Verification
- [x] Affiliate links added to 3 mindfulness/mental wellness posts and 3 self-improvement/personal-growth posts
- [x] Verified links use `target="_blank"` and `rel="noopener noreferrer sponsored"`
- [x] Verified PR diff changes only the six selected HTML files
- [x] No npm/build step run, per static HTML issue instructions