### PR TITLE
[codex] Sync canonical AGIOS scripts

### DIFF
--- a/.github/scripts/reset_stale_locks.py
+++ b/.github/scripts/reset_stale_locks.py
@@ -1,94 +1,139 @@
 #!/usr/bin/env python3
+"""Reconcile stale AGIOS in-progress issues.
+
+Rules:
+- stale lock + linked open PR: move issue to needs-review
+- stale lock + merged closing PR: close issue and mark implemented
+- stale lock + closed unmerged closing PR: mark blocked for human review
+- stale lock + no PR: return to the original queue when known
 """
-AGIOS reset_stale_locks.py
-For each open agios:in-progress issue updated >2h ago with no linked open PR:
-  - Remove agios:in-progress
-  - Re-apply agios:ready-for-codex
-  - Post [AGIOS STALE LOCK RESET] comment
-"""
-import json, os, re, subprocess
-from datetime import datetime, timezone, timedelta
+import json
+import os
+import re
+import subprocess
+from datetime import datetime, timedelta, timezone
 
 REPO = os.environ.get("GITHUB_REPOSITORY", "")
-STALE_THRESHOLD = timedelta(hours=2)
+STALE_AFTER = timedelta(hours=2)
+IN_PROGRESS = "agios:in-progress"
+READY = "agios:ready-for-codex"
+ESCALATE_CODEX = "agios:escalate-codex"
+NEEDS_REVIEW = "agios:needs-review"
+BLOCKED = "agios:blocked"
+IMPLEMENTED = "agios:implemented"
 
 
 def run(cmd):
-    r = subprocess.run(cmd, shell=True, capture_output=True, text=True)
-    return r.stdout.strip()
+    return subprocess.run(cmd, shell=True, capture_output=True, text=True).stdout.strip()
 
 
-def get_in_progress():
-    out = run(f'gh issue list --repo "{REPO}" --label "agios:in-progress" --state open --json number,title,updatedAt --limit 100')
-    try:
-        return json.loads(out)
-    except Exception:
-        return []
+def linked_prs(issue_number):
+    raw = run(f'gh pr list --repo "{REPO}" --state all --json number,body,state,mergedAt,url --limit 100')
+    prs = json.loads(raw or "[]")
+    pattern = re.compile(rf"\b(?:[Cc]loses?|[Ff]ixes|[Rr]esolves?)\s+#\s*{issue_number}\b")
+    return [pr for pr in prs if pattern.search(pr.get("body") or "")]
 
 
-def get_open_pr_for_issue(num):
-    """Check if any open PR body references this issue number."""
-    prs = run(f'gh pr list --repo "{REPO}" --state open --json number,body --limit 50')
-    try:
-        pr_list = json.loads(prs)
-    except Exception:
-        return None
-    pattern = re.compile(rf"[Cc]loses?\s+#\s*{num}\b")
-    for pr in pr_list:
-        if pattern.search(pr.get("body") or ""):
-            return pr["number"]
-    return None
+def original_queue_label(issue_number):
+    raw = run(f'gh issue view {issue_number} --repo "{REPO}" --json labels')
+    data = json.loads(raw or "{}")
+    labels = {label.get("name") for label in data.get("labels") or []}
+    if ESCALATE_CODEX in labels:
+        return ESCALATE_CODEX
+    if READY in labels:
+        return READY
+
+    raw = run(f'gh issue view {issue_number} --repo "{REPO}" --json comments')
+    data = json.loads(raw or "{}")
+    for comment in reversed(data.get("comments") or []):
+        body = comment.get("body") or ""
+        if re.search(rf"(?:Original queue|Queue):\s*`?{re.escape(ESCALATE_CODEX)}`?", body, re.I):
+            return ESCALATE_CODEX
+        if re.search(rf"(?:Original queue|Queue):\s*`?{re.escape(READY)}`?", body, re.I):
+            return READY
+        if ESCALATE_CODEX in body:
+            return ESCALATE_CODEX
+        if READY in body:
+            return READY
+    return READY
 
 
-def reset_lock(num, title, reason):
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    run(f'gh issue edit {num} --repo "{REPO}" --remove-label "agios:in-progress"')
-    run(f'gh issue edit {num} --repo "{REPO}" --add-label "agios:ready-for-codex"')
-    comment = f"[AGIOS STALE LOCK RESET] — returned to `agios:ready-for-codex` at {now}\n\nReason: {reason}"
-    run(f'gh issue comment {num} --repo "{REPO}" --body {json.dumps(comment)}')
+def add_label(num, label):
+    run(f'gh issue edit {num} --repo "{REPO}" --add-label "{label}"')
+
+
+def remove_label(num, label):
+    run(f'gh issue edit {num} --repo "{REPO}" --remove-label "{label}"')
+
+
+def comment(num, body):
+    run(f'gh issue comment {num} --repo "{REPO}" --body {json.dumps(body)}')
 
 
 def main():
     if not REPO:
-        print("GITHUB_REPOSITORY not set — skipping stale lock check")
+        print("GITHUB_REPOSITORY not set")
         return
-
-    issues = get_in_progress()
-    print(f"Checking {len(issues)} in-progress issue(s) for stale locks...")
-
+    raw = run(f'gh issue list --repo "{REPO}" --label "{IN_PROGRESS}" --state open --json number,title,updatedAt --limit 100')
+    issues = json.loads(raw or "[]")
     now = datetime.now(timezone.utc)
-    reset_count = 0
-
     for issue in issues:
-        num        = issue["number"]
-        title      = issue["title"]
-        updated_at = issue.get("updatedAt", "")
-
-        try:
-            updated = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
-        except Exception:
-            print(f"  SKIP #{num}: could not parse updatedAt ({updated_at})")
-            continue
-
+        updated = datetime.fromisoformat(issue["updatedAt"].replace("Z", "+00:00"))
         age = now - updated
-        if age < STALE_THRESHOLD:
-            print(f"  ✓ #{num} {title} — active ({int(age.total_seconds() // 60)}m old)")
+        if age < STALE_AFTER:
+            continue
+        num = issue["number"]
+        prs = linked_prs(num)
+        open_pr = next((pr for pr in prs if pr.get("state") == "OPEN"), None)
+        merged_pr = next((pr for pr in prs if pr.get("mergedAt")), None)
+        closed_pr = next((pr for pr in prs if pr.get("state") == "CLOSED" and not pr.get("mergedAt")), None)
+
+        remove_label(num, IN_PROGRESS)
+
+        if open_pr:
+            add_label(num, NEEDS_REVIEW)
+            body = "[AGIOS STALE LOCK RECONCILED] Moved to `agios:needs-review` at {}\n\nReason: linked open PR exists after {} minutes.\n\nLinked PR: {}".format(
+                now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                int(age.total_seconds() // 60),
+                open_pr.get("url"),
+            )
+            comment(num, body)
+            print(f"RECONCILED #{num} -> PR #{open_pr['number']}")
             continue
 
-        # Check for linked open PR
-        pr = get_open_pr_for_issue(num)
-        if pr:
-            print(f"  ✓ #{num} {title} — stale timestamp but has open PR #{pr}")
+        if merged_pr:
+            remove_label(num, READY)
+            remove_label(num, ESCALATE_CODEX)
+            remove_label(num, NEEDS_REVIEW)
+            add_label(num, IMPLEMENTED)
+            run(f'gh issue close {num} --repo "{REPO}" --reason completed')
+            body = "[AGIOS MERGE FOLLOW-THROUGH] Closed and marked `agios:implemented` at {}\n\nReason: linked PR was merged.\n\nLinked PR: {}".format(
+                now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                merged_pr.get("url"),
+            )
+            comment(num, body)
+            print(f"IMPLEMENTED #{num} -> PR #{merged_pr['number']}")
             continue
 
-        # Stale and no PR — reset
-        reason = f"No linked open PR found after {int(age.total_seconds() // 3600)}h {int((age.total_seconds() % 3600) // 60)}m"
-        print(f"  ⚠ #{num} {title} — RESETTING ({reason})")
-        reset_lock(num, title, reason)
-        reset_count += 1
+        if closed_pr:
+            add_label(num, BLOCKED)
+            body = "[AGIOS STALE LOCK BLOCKED] Marked `agios:blocked` at {}\n\nReason: linked PR was closed without merge.\n\nLinked PR: {}".format(
+                now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                closed_pr.get("url"),
+            )
+            comment(num, body)
+            print(f"BLOCKED #{num} -> PR #{closed_pr['number']}")
+            continue
 
-    print(f"\nStale lock check complete: {reset_count}/{len(issues)} lock(s) reset")
-
+        queue_label = original_queue_label(num)
+        add_label(num, queue_label)
+        body = "[AGIOS STALE LOCK RESET] Returned to `{}` at {}\n\nReason: no linked PR after {} minutes.".format(
+            queue_label,
+            now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            int(age.total_seconds() // 60),
+        )
+        comment(num, body)
+        print(f"RESET #{num} {issue['title']} -> {queue_label}")
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/validate_issues.py
+++ b/.github/scripts/validate_issues.py
@@ -1,121 +1,120 @@
 #!/usr/bin/env python3
-"""
-AGIOS validate_issues.py
-For each open agios:ready-for-codex issue, checks required fields and flags contradictions.
-On failure: removes agios:ready-for-codex, applies agios:needs-scope, posts comment.
-"""
-import json, os, re, subprocess, sys
-from datetime import datetime
+"""Validate AGIOS queue issues and move malformed items to needs-scope."""
+import json
+import os
+import re
+import subprocess
+from datetime import datetime, timezone
 
 REPO = os.environ.get("GITHUB_REPOSITORY", "")
-GH_TOKEN = os.environ.get("GH_TOKEN", "")
+QUEUE_LABELS = ["agios:ready-for-codex", "agios:escalate-codex"]
 
-REQUIRED_FIELDS = [
-    ("Type",                  r"\*\*Type:\*\*\s*(\S+)"),
-    ("Objective",             r"\*\*Objective:\*\*\s*(.+)"),
-    ("Allowed paths",         r"\*\*Allowed paths:\*\*"),
-    ("Blocked paths",         r"\*\*Blocked paths:\*\*"),
+REQUIRED = [
+    ("Type", r"\*\*Type:\*\*\s*(RESEARCH|MAINTENANCE|IMPROVEMENT|EXPERIMENT)"),
+    ("Objective", r"\*\*Objective:\*\*\s*\S"),
+    ("Allowed paths", r"\*\*Allowed paths:\*\*"),
+    ("Blocked paths", r"\*\*Blocked paths:\*\*"),
     ("Implementation instructions", r"\*\*Implementation instructions:\*\*"),
-    ("Acceptance criteria",   r"- \[ \]"),
-    ("Verification command",  r"\*\*Verification command:\*\*\s*```(?:bash|shell|sh)?\s*\n\s*\S[\s\S]*?\n```"),
-    ("Rollback plan",         r"\*\*Rollback plan:\*\*\s*(.+)"),
-    ("Risk level",            r"\*\*Risk level:\*\*\s*(LOW|MEDIUM|HIGH)"),
-    ("Auto-merge allowed",    r"\*\*Auto-merge allowed:\*\*\s*(yes|no)"),
-    ("Success metric",        r"\*\*Success metric:\*\*\s*(.+)"),
+    ("Acceptance criteria", r"- \[ \]\s*\S"),
+    ("Verification command", r"\*\*Verification command:\*\*\s*```(?:bash|shell|sh)?\s*\n\s*\S[\s\S]*?\n```"),
+    ("Rollback plan", r"\*\*Rollback plan:\*\*\s*\S"),
+    ("Risk level", r"\*\*Risk level:\*\*\s*(LOW|MEDIUM|HIGH)"),
+    ("Auto-merge allowed", r"\*\*Auto-merge allowed:\*\*\s*(yes|no)"),
 ]
-
-VALID_TYPES = {"IMPROVEMENT", "MAINTENANCE", "RESEARCH", "EXPERIMENT"}
 
 
 def run(cmd):
-    r = subprocess.run(cmd, shell=True, capture_output=True, text=True)
-    return r.stdout.strip()
+    return subprocess.run(cmd, shell=True, capture_output=True, text=True).stdout.strip()
 
 
-def get_issues():
-    out = run(f'gh issue list --repo "{REPO}" --label "agios:ready-for-codex" --state open --json number,title,body --limit 100')
-    try:
-        return json.loads(out)
-    except Exception:
-        return []
+def section(body, heading):
+    match = re.search(
+        rf"\*\*{re.escape(heading)}:\*\*\s*(.*?)(?=\n\*\*[^*\n]+:\*\*|\Z)",
+        body or "",
+        re.I | re.S,
+    )
+    return match.group(1).strip() if match else ""
 
 
-def validate(issue):
-    body = issue.get("body") or ""
+def list_section(body, heading):
+    raw = section(body, heading)
+    values = []
+    for line in raw.splitlines():
+        cleaned = line.strip().lstrip("-").strip()
+        if cleaned and not cleaned.startswith("```"):
+            values.append(cleaned)
+    return values
+
+
+def verification_command(body):
+    raw = section(body, "Verification command")
+    match = re.search(r"```(?:bash|shell|sh)?\s*\n(.*?)\n```", raw, re.I | re.S)
+    return (match.group(1) if match else raw).strip()
+
+
+def problems_for(title, body):
     problems = []
+    for name, pattern in REQUIRED:
+        if not re.search(pattern, body or "", re.I | re.M):
+            problems.append(f"Missing or empty: **{name}:**")
+    if re.search(r"\*\*Risk level:\*\*\s*HIGH", body or "", re.I) and re.search(r"\*\*Auto-merge allowed:\*\*\s*yes", body or "", re.I):
+        problems.append("Contradiction: HIGH risk cannot auto-merge")
+    if re.search(r"\bTBD\b|\[placeholder\]", body or "", re.I):
+        problems.append("Contains placeholder text")
 
-    # Check required fields
-    for name, pattern in REQUIRED_FIELDS:
-        if not re.search(pattern, body, re.IGNORECASE | re.MULTILINE):
-            problems.append(f"Missing or empty: `**{name}:**`")
+    title_starts_infra = title.lower().startswith("agios infra:")
+    allowed_paths = list_section(body, "Allowed paths")
+    blocked_paths = list_section(body, "Blocked paths")
+    verification = verification_command(body)
 
-    # Validate Type value
-    m = re.search(r"\*\*Type:\*\*\s*(\S+)", body, re.IGNORECASE)
-    if m and m.group(1).upper() not in VALID_TYPES:
-        problems.append(f"Invalid Type `{m.group(1)}` — must be one of: IMPROVEMENT, MAINTENANCE, RESEARCH, EXPERIMENT")
+    forbidden_allowed = []
+    for path in allowed_paths:
+        if re.search(r"(^|/)\.github(/|$)|(^|/)\.agios(/|$)|(^|/)\.env$|\.env", path):
+            forbidden_allowed.append(path)
+    if forbidden_allowed and not title_starts_infra:
+        problems.append("Allowed paths include blocked infrastructure or secret paths: " + ", ".join(forbidden_allowed))
 
-    # Contradiction: Risk HIGH + Auto-merge yes
-    risk_high = bool(re.search(r"\*\*Risk level:\*\*\s*HIGH", body, re.IGNORECASE))
-    auto_yes  = bool(re.search(r"\*\*Auto-merge allowed:\*\*\s*yes", body, re.IGNORECASE))
-    if risk_high and auto_yes:
-        problems.append("Contradiction: `Risk level: HIGH` + `Auto-merge allowed: yes`")
+    blocked_normalized = {item.rstrip("/") for item in blocked_paths}
+    for path in allowed_paths:
+        normalized = path.rstrip("/")
+        if normalized in blocked_normalized:
+            problems.append(f"Allowed path also appears in blocked paths: {path}")
 
-    # Contradiction: Allowed paths contains protected dirs
-    allowed_section = re.search(r"\*\*Allowed paths:\*\*(.*?)(\*\*|\Z)", body, re.DOTALL)
-    if allowed_section:
-        section_text = allowed_section.group(1)
-        for protected in [".github/", ".agios/", ".env"]:
-            if protected in section_text:
-                problems.append(f"Contradiction: Allowed paths contains protected path `{protected}`")
-
-    # Flag placeholder content
-    if re.search(r"\bTBD\b|\[placeholder\]", body, re.IGNORECASE):
-        problems.append("Body contains placeholder text (`TBD` or `[placeholder]`)")
+    if re.search(r"(?<![\w.-])python(?![\w.-])", verification):
+        problems.append("Verification command must use python3, not python")
+    if "/workspace" in verification:
+        problems.append("Verification command must run from the repository root, not /workspace")
+    if re.search(r"\|\s*tail\b", verification):
+        problems.append("Verification command must not hide failures with tail-truncated output")
 
     return problems
 
 
-def flag_issue(num, problems):
-    # Remove ready-for-codex, add needs-scope
-    run(f'gh issue edit {num} --repo "{REPO}" --remove-label "agios:ready-for-codex"')
-    run(f'gh issue edit {num} --repo "{REPO}" --add-label "agios:needs-scope"')
-
-    # Post comment
-    problem_list = "\n".join(f"- {p}" for p in problems)
-    comment = f"""[AGIOS QUEUE HEALTH] Issue failed schema validation at {datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')}
-
-**Problems found:**
-{problem_list}
-
-Label changed: `agios:ready-for-codex` → `agios:needs-scope`
-Fix the issues above and re-apply `agios:ready-for-codex` to re-queue."""
-    run(f'gh issue comment {num} --repo "{REPO}" --body {json.dumps(comment)}')
-
-
 def main():
     if not REPO:
-        print("GITHUB_REPOSITORY not set — skipping validation")
+        print("GITHUB_REPOSITORY not set")
         return
-
-    issues = get_issues()
-    print(f"Validating {len(issues)} ready-for-codex issue(s)...")
-
-    flagged = 0
-    for issue in issues:
-        num   = issue["number"]
-        title = issue["title"]
-        problems = validate(issue)
-        if problems:
-            print(f"  WARNING #{num} {title} — {len(problems)} problem(s)")
-            for p in problems:
-                print(f"      {p}")
-            flag_issue(num, problems)
-            flagged += 1
-        else:
-            print(f"  OK #{num} {title}")
-
-    print(f"\nValidation complete: {flagged}/{len(issues)} issue(s) flagged")
-
+    seen = set()
+    for queue_label in QUEUE_LABELS:
+        raw = run(f'gh issue list --repo "{REPO}" --label "{queue_label}" --state open --json number,title,body --limit 100')
+        issues = json.loads(raw or "[]")
+        for issue in issues:
+            num = issue["number"]
+            if num in seen:
+                continue
+            seen.add(num)
+            problems = problems_for(issue.get("title") or "", issue.get("body") or "")
+            if not problems:
+                print(f"OK #{num} {issue['title']}")
+                continue
+            run(f'gh issue edit {num} --repo "{REPO}" --remove-label "{queue_label}"')
+            run(f'gh issue edit {num} --repo "{REPO}" --add-label "agios:needs-scope"')
+            body = "[AGIOS QUEUE HEALTH] Issue failed schema validation at {}\n\n{}".format(
+                datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "\n".join(f"- {p}" for p in problems),
+            )
+            run(f'gh issue comment {num} --repo "{REPO}" --body {json.dumps(body)}')
+            print(f"FLAGGED #{num} {issue['title']}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Sync `.github/scripts/reset_stale_locks.py` and `.github/scripts/validate_issues.py` from canonical `agios-control/scripts/agios/`.
- Leaves `.github/scripts/check_scope.py` unchanged because it already matched the canonical behavior.
- Canonical source landed in https://github.com/msarmento42/agios-control/pull/23 (`6a09bb7`).

## Behavioral Drift Decisions
- Kept downstream Type validation and protected-path validation by merging those checks into canonical first.
- Kept canonical validation for both `agios:ready-for-codex` and `agios:escalate-codex`.
- Kept canonical verification-command checks for `python3`, no `/workspace`, and no `| tail`.
- Replaced stale-lock reset behavior so escalation-origin issues restore `agios:escalate-codex` instead of being demoted to `agios:ready-for-codex`.

## Verification
- `PYTHONPYCACHEPREFIX=.pycache python3 -m py_compile .github/scripts/reset_stale_locks.py .github/scripts/validate_issues.py .github/scripts/check_scope.py`
- `git diff --check`