### PR TITLE
Add Open Graph meta tags to blog posts

### DIFF
--- a/blog/atomic-habits-key-lessons.html
+++ b/blog/atomic-habits-key-lessons.html
@@ -5,6 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="The key lessons from Atomic Habits by James Clear — the ideas that will actually change how you think about behavior, systems, and lasting change.">
 <title>Atomic Habits: The Key Lessons That Will Change Your Behavior | Motivational Quote</title>
+<link rel="canonical" href="https://motivational-quote.org/blog/atomic-habits-key-lessons.html">
+<meta property="og:title" content="Atomic Habits: The Key Lessons That Will Change Your Behavior | Motivational Quote">
+<meta property="og:description" content="The key lessons from Atomic Habits by James Clear — the ideas that will actually change how you think about behavior, systems, and lasting change.">
+<meta property="og:url" content="https://motivational-quote.org/blog/atomic-habits-key-lessons.html">
+<meta property="og:type" content="article">
+<meta property="og:image" content="https://motivational-quote.org/replit_snapshot/2026-01-29/client/public/favicon.png">
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6175161566333696" crossorigin="anonymous"></script>
 <style>
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#f5f3f0;color:#1f2937;line-height:1.75;padding:0;margin:0}

--- a/blog/building-mental-toughness.html
+++ b/blog/building-mental-toughness.html
@@ -5,6 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="Mental toughness isn't a personality trait — it's a trainable skill. Learn the science-backed methods used by elite athletes and military personnel to build resilience under pressure.">
 <title>Building Mental Toughness: The Science of Performing Under Pressure | Motivational Quote</title>
+<link rel="canonical" href="https://motivational-quote.org/blog/building-mental-toughness.html">
+<meta property="og:title" content="Building Mental Toughness: The Science of Performing Under Pressure | Motivational Quote">
+<meta property="og:description" content="Mental toughness isn&#x27;t a personality trait — it&#x27;s a trainable skill. Learn the science-backed methods used by elite athletes and military personnel to build resilience under pressure.">
+<meta property="og:url" content="https://motivational-quote.org/blog/building-mental-toughness.html">
+<meta property="og:type" content="article">
+<meta property="og:image" content="https://motivational-quote.org/replit_snapshot/2026-01-29/client/public/favicon.png">
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6175161566333696" crossorigin="anonymous"></script>
 <style>
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#f5f3f0;color:#1f2937;line-height:1.75;padding:0;margin:0}

--- a/blog/daily-rituals-of-successful-people.html
+++ b/blog/daily-rituals-of-successful-people.html
@@ -5,6 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="The most successful people in the world share surprisingly consistent daily rituals. Here's what the research and biographies reveal — and how to adapt these habits to your own life.">
 <title>Daily Rituals of Successful People: What the Research Really Shows | Motivational Quote</title>
+<link rel="canonical" href="https://motivational-quote.org/blog/daily-rituals-of-successful-people.html">
+<meta property="og:title" content="Daily Rituals of Successful People: What the Research Really Shows | Motivational Quote">
+<meta property="og:description" content="The most successful people in the world share surprisingly consistent daily rituals. Here&#x27;s what the research and biographies reveal — and how to adapt these habits to your own life.">
+<meta property="og:url" content="https://motivational-quote.org/blog/daily-rituals-of-successful-people.html">
+<meta property="og:type" content="article">
+<meta property="og:image" content="https://motivational-quote.org/replit_snapshot/2026-01-29/client/public/favicon.png">
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6175161566333696" crossorigin="anonymous"></script>
 <style>
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#f5f3f0;color:#1f2937;line-height:1.75;padding:0;margin:0}

--- a/blog/how-to-build-self-confidence.html
+++ b/blog/how-to-build-self-confidence.html
@@ -5,6 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="Real self-confidence isn't something you're born with — it's a skill built through deliberate action. Learn the evidence-backed steps to build lasting self-confidence from the ground up.">
 <title>How to Build Self-Confidence That Actually Lasts | Motivational Quote</title>
+<link rel="canonical" href="https://motivational-quote.org/blog/how-to-build-self-confidence.html">
+<meta property="og:title" content="How to Build Self-Confidence That Actually Lasts | Motivational Quote">
+<meta property="og:description" content="Real self-confidence isn&#x27;t something you&#x27;re born with — it&#x27;s a skill built through deliberate action. Learn the evidence-backed steps to build lasting self-confidence from the ground up.">
+<meta property="og:url" content="https://motivational-quote.org/blog/how-to-build-self-confidence.html">
+<meta property="og:type" content="article">
+<meta property="og:image" content="https://motivational-quote.org/replit_snapshot/2026-01-29/client/public/favicon.png">
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6175161566333696" crossorigin="anonymous"></script>
 <style>
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#f5f3f0;color:#1f2937;line-height:1.75;padding:0;margin:0}

--- a/blog/how-to-stay-motivated-long-term.html
+++ b/blog/how-to-stay-motivated-long-term.html
@@ -5,6 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="Motivation fades — but sustained drive doesn't have to. Learn the psychology-backed strategies that keep high performers moving forward long after the initial excitement dies out.">
 <title>How to Stay Motivated Long-Term | Motivational Quote</title>
+<link rel="canonical" href="https://motivational-quote.org/blog/how-to-stay-motivated-long-term.html">
+<meta property="og:title" content="How to Stay Motivated Long-Term | Motivational Quote">
+<meta property="og:description" content="Motivation fades — but sustained drive doesn&#x27;t have to. Learn the psychology-backed strategies that keep high performers moving forward long after the initial excitement dies out.">
+<meta property="og:url" content="https://motivational-quote.org/blog/how-to-stay-motivated-long-term.html">
+<meta property="og:type" content="article">
+<meta property="og:image" content="https://motivational-quote.org/replit_snapshot/2026-01-29/client/public/favicon.png">
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6175161566333696" crossorigin="anonymous"></script>
 <style>
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#f5f3f0;color:#1f2937;line-height:1.75;padding:0;margin:0}

--- a/blog/lessons-from-stoic-philosophers.html
+++ b/blog/lessons-from-stoic-philosophers.html
@@ -5,6 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="Marcus Aurelius, Epictetus, and Seneca developed timeless tools for living well under pressure. Discover the most actionable lessons from Stoic philosophy for modern life.">
 <title>Lessons From Stoic Philosophers That Still Work Today | Motivational Quote</title>
+<link rel="canonical" href="https://motivational-quote.org/blog/lessons-from-stoic-philosophers.html">
+<meta property="og:title" content="Lessons From Stoic Philosophers That Still Work Today | Motivational Quote">
+<meta property="og:description" content="Marcus Aurelius, Epictetus, and Seneca developed timeless tools for living well under pressure. Discover the most actionable lessons from Stoic philosophy for modern life.">
+<meta property="og:url" content="https://motivational-quote.org/blog/lessons-from-stoic-philosophers.html">
+<meta property="og:type" content="article">
+<meta property="og:image" content="https://motivational-quote.org/replit_snapshot/2026-01-29/client/public/favicon.png">
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6175161566333696" crossorigin="anonymous"></script>
 <style>
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#f5f3f0;color:#1f2937;line-height:1.75;padding:0;margin:0}

--- a/blog/mindfulness-for-beginners.html
+++ b/blog/mindfulness-for-beginners.html
@@ -5,6 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="Mindfulness for beginners: learn how to start a simple practice in just 5 minutes a day. No experience needed — just an open mind and a few minutes.">
 <title>Mindfulness for Beginners: Start in 5 Minutes a Day | Motivational Quote</title>
+<link rel="canonical" href="https://motivational-quote.org/blog/mindfulness-for-beginners.html">
+<meta property="og:title" content="Mindfulness for Beginners: Start in 5 Minutes a Day | Motivational Quote">
+<meta property="og:description" content="Mindfulness for beginners: learn how to start a simple practice in just 5 minutes a day. No experience needed — just an open mind and a few minutes.">
+<meta property="og:url" content="https://motivational-quote.org/blog/mindfulness-for-beginners.html">
+<meta property="og:type" content="article">
+<meta property="og:image" content="https://motivational-quote.org/replit_snapshot/2026-01-29/client/public/favicon.png">
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6175161566333696" crossorigin="anonymous"></script>
 <style>
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#f5f3f0;color:#1f2937;line-height:1.75;padding:0;margin:0}

--- a/blog/overcoming-procrastination.html
+++ b/blog/overcoming-procrastination.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Overcoming Procrastination: The Psychology Behind Delay and How to Beat It</title>
+<link rel="canonical" href="https://motivational-quote.org/blog/overcoming-procrastination.html">
+<meta property="og:title" content="Overcoming Procrastination: The Psychology Behind Delay and How to Beat It">
+<meta property="og:description" content="Procrastination isn&#x27;t a character flaw—it&#x27;s an emotional regulation problem. Understanding why you delay reveals how to stop.">
+<meta property="og:url" content="https://motivational-quote.org/blog/overcoming-procrastination.html">
+<meta property="og:type" content="article">
+<meta property="og:image" content="https://motivational-quote.org/replit_snapshot/2026-01-29/client/public/favicon.png">
     <style>
         :root { --primary: #6366f1; --secondary: #8b5cf6; --bg: #0f172a; --card-bg: #1e293b; --text: #f8fafc; --text-muted: #94a3b8; --border: #334155; }
         [data-theme="light"] { --bg: #f8fafc; --card-bg: #ffffff; --text: #1e293b; --text-muted: #64748b; --border: #e2e8f0; }

--- a/blog/the-compound-effect-explained.html
+++ b/blog/the-compound-effect-explained.html
@@ -5,6 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="The compound effect is the most powerful force in personal growth — and most people misunderstand it. Learn how small, consistent actions snowball into extraordinary results over time.">
 <title>The Compound Effect Explained | Motivational Quote</title>
+<link rel="canonical" href="https://motivational-quote.org/blog/the-compound-effect-explained.html">
+<meta property="og:title" content="The Compound Effect Explained | Motivational Quote">
+<meta property="og:description" content="The compound effect is the most powerful force in personal growth — and most people misunderstand it. Learn how small, consistent actions snowball into extraordinary results over time.">
+<meta property="og:url" content="https://motivational-quote.org/blog/the-compound-effect-explained.html">
+<meta property="og:type" content="article">
+<meta property="og:image" content="https://motivational-quote.org/replit_snapshot/2026-01-29/client/public/favicon.png">
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6175161566333696" crossorigin="anonymous"></script>
 <style>
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#f5f3f0;color:#1f2937;line-height:1.75;padding:0;margin:0}

--- a/blog/the-science-of-habit-formation.html
+++ b/blog/the-science-of-habit-formation.html
@@ -6,6 +6,11 @@
     <meta name="description" content="Understanding the neuroscience behind habits and how to create lasting behavioral change through proven psychological principles.">
     <title>The Science of Habit Formation: How to Rewire Your Brain for Lasting Change</title>
     <link rel="canonical" href="https://motivational-quote.org/blog/the-science-of-habit-formation.html">
+<meta property="og:title" content="The Science of Habit Formation: How to Rewire Your Brain for Lasting Change">
+<meta property="og:description" content="Understanding the neuroscience behind habits and how to create lasting behavioral change through proven psychological principles.">
+<meta property="og:url" content="https://motivational-quote.org/blog/the-science-of-habit-formation.html">
+<meta property="og:type" content="article">
+<meta property="og:image" content="https://motivational-quote.org/replit_snapshot/2026-01-29/client/public/favicon.png">
     <style>
         :root { --primary: #6366f1; --secondary: #8b5cf6; --bg: #0f172a; --card-bg: #1e293b; --text: #f8fafc; --text-muted: #94a3b8; --border: #334155; }
         [data-theme="light"] { --bg: #f8fafc; --card-bg: #ffffff; --text: #1e293b; --text-muted: #64748b; --border: #e2e8f0; }


### PR DESCRIPTION
## Summary
- Add canonical URLs and Open Graph metadata to the 10 scoped blog articles.
- Use each page title and description for social previews.
- Set article `og:type` and a shared site image URL for preview metadata.

Closes #46

## Verification
- Issue body snapshot at claim: `ce37f5829b178323`
- `python3 -c "import glob, html.parser; [html.parser.HTMLParser().feed(open(f).read()) for f in glob.glob('blog/*.html')[:10]]; print('HTML OK')"`
- `python3 - <<'PY' ...` targeted check confirmed all 10 scoped pages include `og:title`, `og:description`, `og:url`, `og:type`, `og:image`, and matching canonical/OG URLs.
- `git diff --check`