### PR TITLE
Add OG tags to static pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,6 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>About Us – Motivational-Quote.org</title>
   <meta name="description" content="Learn about Motivational-Quote.org — why we built it, what we publish, and our standards for quotes and personal growth content." />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="About Us – Motivational-Quote.org" />
+  <meta property="og:description" content="Learn about Motivational-Quote.org — why we built it, what we publish, and our standards for quotes and personal growth content." />
+  <meta property="og:url" content="https://motivational-quote.org/about.html" />
   <meta name="robots" content="index,follow" />
   <link rel="canonical" href="https://motivational-quote.org/about.html" />
   <link rel="stylesheet" href="style.css" />

--- a/contact.html
+++ b/contact.html
@@ -5,6 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Contact – Motivational-Quote.org</title>
   <meta name="description" content="Contact Motivational-Quote.org with feedback, suggestions, or collaboration ideas. We’d love to hear from you." />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Contact – Motivational-Quote.org" />
+  <meta property="og:description" content="Contact Motivational-Quote.org with feedback, suggestions, or collaboration ideas. We’d love to hear from you." />
+  <meta property="og:url" content="https://motivational-quote.org/contact.html" />
   <meta name="robots" content="index,follow" />
   <link rel="canonical" href="https://motivational-quote.org/contact.html" />
   <link rel="stylesheet" href="style.css" />

--- a/privacy.html
+++ b/privacy.html
@@ -5,6 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Privacy Policy – Motivational-Quote.org</title>
   <meta name="description" content="How Motivational-Quote.org handles data, cookies, and advertising (including Google AdSense)." />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Privacy Policy – Motivational-Quote.org" />
+  <meta property="og:description" content="How Motivational-Quote.org handles data, cookies, and advertising (including Google AdSense)." />
+  <meta property="og:url" content="https://motivational-quote.org/privacy.html" />
   <meta name="robots" content="index,follow" />
   <link rel="canonical" href="https://motivational-quote.org/privacy.html" />
   <link rel="stylesheet" href="style.css" />

--- a/resources.html
+++ b/resources.html
@@ -5,6 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Recommended Resources – Motivational-Quote.org</title>
   <meta name="description" content="Our recommended books, audiobooks, and mindfulness tools for personal growth, focus, and lasting motivation. Curated by the Motivational-Quote.org team." />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Recommended Resources – Motivational-Quote.org" />
+  <meta property="og:description" content="Our recommended books, audiobooks, and mindfulness tools for personal growth, focus, and lasting motivation. Curated by the Motivational-Quote.org team." />
+  <meta property="og:url" content="https://motivational-quote.org/resources.html" />
   <meta name="robots" content="index,follow" />
   <link rel="canonical" href="https://motivational-quote.org/resources.html" />
   <link rel="stylesheet" href="style.css" />

--- a/subscribe.html
+++ b/subscribe.html
@@ -4,7 +4,12 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="Get weekly motivation, mindset shifts, and actionable advice delivered to your inbox. Free forever.">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Subscribe — Motivational Quote">
+<meta property="og:description" content="Get weekly motivation, mindset shifts, and actionable advice delivered to your inbox. Free forever.">
+<meta property="og:url" content="https://motivational-quote.org/subscribe.html">
 <title>Subscribe — Motivational Quote</title>
+<link rel="canonical" href="https://motivational-quote.org/subscribe.html">
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6175161566333696" crossorigin="anonymous"></script>
 <style>
 *{box-sizing:border-box;margin:0;padding:0}

--- a/terms.html
+++ b/terms.html
@@ -5,6 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Terms of Use – Motivational-Quote.org</title>
   <meta name="description" content="Terms of Use for Motivational-Quote.org. Please read these terms before using the site." />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Terms of Use – Motivational-Quote.org" />
+  <meta property="og:description" content="Terms of Use for Motivational-Quote.org. Please read these terms before using the site." />
+  <meta property="og:url" content="https://motivational-quote.org/terms.html" />
   <meta name="robots" content="index,follow" />
   <link rel="canonical" href="https://motivational-quote.org/terms.html" />
   <link rel="stylesheet" href="style.css" />


### PR DESCRIPTION
Closes #64

## Summary
- Added Open Graph metadata to about, contact, privacy, terms, resources, and subscribe pages.
- Added the missing canonical link to subscribe.html.
- Reused each page's existing title and meta description text for OG tags.

## Verification
- Issue body snapshot at claim: bff816ee3364de14
- `for f in about.html contact.html privacy.html terms.html resources.html subscribe.html; do echo "== $f =="; grep -c "og:title\|og:description\|og:type\|og:url" "$f"; done`
- `python3 -c "import html.parser; files=['about.html','contact.html','privacy.html','terms.html','resources.html','subscribe.html']; [html.parser.HTMLParser().feed(open(f, encoding='utf-8').read()) for f in files]; print('HTML OK')"`
- `git diff --check`
