### PR TITLE
Add Sprint 2 resource conversion paths

### DIFF
--- a/blog/accepting-uncertainty.html
+++ b/blog/accepting-uncertainty.html
@@ -126,6 +126,15 @@
                     <li><strong>Weekly (10 min):</strong> Run a brief fear-setting exercise on your most pressing uncertain situation. Define the worst realistic outcome. Assess recoverability. Identify the upside of action. Compare the cost of inaction to the cost of the worst-case scenario.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/active-listening.html
+++ b/blog/active-listening.html
@@ -148,6 +148,15 @@
                     <li><strong>After high-stakes conversations:</strong> Write down what you heard, including subtext and emotional content. Note what you may have missed or misread.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/active-recall-learning.html
+++ b/blog/active-recall-learning.html
@@ -122,6 +122,15 @@
             <p>To put this to work, restructure how you study around output rather than input. Read or watch once to understand, then immediately close the source and retrieve. Convert key ideas into questions or flashcards. Schedule spaced reviews. Periodically explain what you have learned aloud or on a blank page. The ratio should tilt heavily toward retrieval&mdash;most of your study time spent producing, not reviewing.</p>
 
             <p>Done consistently, this approach does not just improve test scores; it changes how much of what you learn you actually keep. For ambitious self-directed learners who want to take this further, our guide to <a href="/blog/ultralearning.html">ultralearning</a> shows how to assemble these principles into intensive, project-based learning, and you can find recommended learning tools on our <a href="../resources.html">resources page</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/adaptive-habits.html
+++ b/blog/adaptive-habits.html
@@ -122,6 +122,15 @@
             <p>Your capacity is not constant across a year, let alone a life. There are intense seasons&mdash;a demanding project, a newborn, a health crisis&mdash;when maintaining any version of a habit is a genuine victory, and expecting growth is unrealistic. There are spacious seasons when you can expand and push. Adaptive habits explicitly plan for both.</p>
 
             <p>In demanding seasons, drop to maintenance: the minimum viable version, no guilt, no growth expected. The aim is simply to keep the habit alive so you do not have to rebuild from zero later. In open seasons, raise the ceiling and chase progress. Treating your routine as a living system you tune to the season&mdash;rather than a fixed contract you either honor or betray&mdash;is what lets it survive for years. You can find tools and frameworks for this kind of seasonal planning on our <a href="../resources.html">resources page</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/adaptive-learning.html
+++ b/blog/adaptive-learning.html
@@ -105,6 +105,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>Cal Newport's <a href="https://www.amazon.com/dp/1455509124?tag=mq061-20" rel="noopener sponsored">So Good They Can't Ignore You</a> makes the case for deliberate practice and adaptive skill-building in career development. Anders Ericsson's <a href="https://www.amazon.com/dp/0544947223?tag=mq061-20" rel="noopener sponsored">Peak: Secrets from the New Science of Expertise</a> is the definitive account of deliberate practice research. Both available on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/anchor-habits.html
+++ b/blog/anchor-habits.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to turn scattered effort into visible progress. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/anticipatory-anxiety.html
+++ b/blog/anticipatory-anxiety.html
@@ -75,6 +75,15 @@
 <h2>Quick Wins: Start Today</h2>
 <p>(1) Identify the next event you're dreading and write down your most likely outcome — not worst or best, just most probable. (2) Schedule a 15-minute worry window tonight and practice redirecting anticipatory thoughts to it during the day. (3) After the next anxiety-provoking event passes, note how close your feared outcome was to reality — this builds evidence against the anxious forecast over time.</p>
 <div style="background:#4f46e5;color:white;padding:25px;border-radius:12px;text-align:center;margin:25px 0"><a href="/subscribe.html" style="background:white;color:#4f46e5;padding:12px 24px;border-radius:25px;text-decoration:none;font-weight:600;">Subscribe Free</a></div></div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>
       <p>Continue with the <a href="/category-mindset-resilience.html">Mindset and Resilience</a> collection or read one of these related articles:</p>

--- a/blog/antifragility.html
+++ b/blog/antifragility.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/anxiety-management.html
+++ b/blog/anxiety-management.html
@@ -40,6 +40,15 @@
 <h2>Quick Wins: Start Today</h2>
 <p>Try these three right now: (1) Do one round of box breathing — four counts in, hold, out, hold. Notice how your nervous system responds. (2) Write down one thing you're currently anxious about, then write the most realistic (not best or worst case) outcome. (3) Identify one small situation you've been avoiding because of anxiety and commit to approaching it this week — even for just two minutes.</p>
 <div style="background:#4f46e5;color:white;padding:25px;border-radius:12px;text-align:center;margin:25px 0"><a href="/subscribe.html" style="background:white;color:#4f46e5;padding:12px 24px;border-radius:25px;text-decoration:none;font-weight:600;">Subscribe Free</a></div></div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>
       <p>Continue with the <a href="/category-mindset-resilience.html">Mindset and Resilience</a> collection or read one of these related articles:</p>

--- a/blog/asking-questions.html
+++ b/blog/asking-questions.html
@@ -142,6 +142,15 @@
                     <li><strong>Evening (2 min):</strong> Write the best question that came to you today. What made it generative? What question do you wish you'd asked?</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/atomic-habits-key-lessons.html
+++ b/blog/atomic-habits-key-lessons.html
@@ -109,6 +109,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/attention-residue.html
+++ b/blog/attention-residue.html
@@ -113,6 +113,15 @@
             <p>Putting it together, a low-residue day looks deliberately different from the default. Notifications are off by default, not on. Email and messages live in scheduled windows, not the background of every minute. The most demanding work gets a protected morning block before the day's interruptions begin. And every forced switch is preceded by a quick ready-to-resume note.</p>
 
             <p>Mindfulness training helps here too, because it strengthens the very muscle attention residue strains: the ability to notice when your mind has drifted to the previous task and gently return it to the present one. A few minutes a day with <a href="https://headspace.com" rel="noopener sponsored">Headspace</a> builds exactly that metacognitive awareness. Pair the practice with the structural changes above and you can find curated focus tools on our <a href="../resources.html">resources page</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/attribution-errors.html
+++ b/blog/attribution-errors.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/authentic-networking.html
+++ b/blog/authentic-networking.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to build trust without performing or forcing it. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/autonomy-mastery-purpose.html
+++ b/blog/autonomy-mastery-purpose.html
@@ -148,6 +148,15 @@
             </div>
 
             <p>The same diagnostic applies to personal projects, creative work, and habits. A habit that is consistently abandoned is often one in which the mastery component is absent (no sense of progress), the autonomy component is absent (it was adopted because you "should," not because you chose it), or the purpose component is absent (the connection between the habit and something you genuinely care about has not been made explicit). Our piece on <a href="/blog/identity-based-habits.html">identity-based habits</a> connects to this directly: the most durable habits are those that connect to who you are becoming, which is a form of purpose. Find additional frameworks for sustaining long-term motivation on our <a href="../resources.html">resources page</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/barbell-strategy.html
+++ b/blog/barbell-strategy.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/beginners-mind.html
+++ b/blog/beginners-mind.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/body-language.html
+++ b/blog/body-language.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to build trust without performing or forcing it. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/breaking-bad-habits-for-good.html
+++ b/blog/breaking-bad-habits-for-good.html
@@ -112,6 +112,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/building-a-second-brain.html
+++ b/blog/building-a-second-brain.html
@@ -144,6 +144,15 @@
                     <li>The goal is creation, not collection—a full archive is not the same as progress</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/building-mental-toughness.html
+++ b/blog/building-mental-toughness.html
@@ -117,6 +117,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/building-resilience-after-loss.html
+++ b/blog/building-resilience-after-loss.html
@@ -110,6 +110,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/celebrating-wins.html
+++ b/blog/celebrating-wins.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/champion-habits.html
+++ b/blog/champion-habits.html
@@ -141,6 +141,15 @@
                     <li>Tie habits to identity, and live by "never miss twice"</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/choice-architecture.html
+++ b/blog/choice-architecture.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to turn scattered effort into visible progress. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/chronotype-productivity.html
+++ b/blog/chronotype-productivity.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to turn scattered effort into visible progress. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/circle-competence.html
+++ b/blog/circle-competence.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/cognitive-flexibility.html
+++ b/blog/cognitive-flexibility.html
@@ -128,6 +128,15 @@
                     <li><strong>End-of-day update audit:</strong> What changed today that you hadn't anticipated? Did you update your views and plans accordingly, or hold to the original framing? Where you held on — was that because the evidence genuinely didn't warrant updating, or because updating felt costly?</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/cognitive-load-management.html
+++ b/blog/cognitive-load-management.html
@@ -143,6 +143,15 @@
                     <li>Emotional and cognitive load compete for the same resource. Managing stress and unresolved emotional concerns is cognitive performance management.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/cognitive-reframing.html
+++ b/blog/cognitive-reframing.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/comfort-zone-expansion.html
+++ b/blog/comfort-zone-expansion.html
@@ -83,6 +83,15 @@
 <p>Comfort zone expansion becomes easier when you accept that discomfort is part of growth, not a sign to retreat.</p>
 
 <p>The life you want exists on the other side of your comfort zone. Each small expansion makes the next one easier.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/commitment-devices.html
+++ b/blog/commitment-devices.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to turn scattered effort into visible progress. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/competition-self.html
+++ b/blog/competition-self.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to build trust without performing or forcing it. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/continuous-improvement.html
+++ b/blog/continuous-improvement.html
@@ -68,6 +68,15 @@
 <h2>Further Reading</h2><p>For the definitive guide on building improvement systems through identity and small habits, <a href="https://www.amazon.com/dp/0735211299?tag=mq061-20" rel="noopener sponsored">Atomic Habits by James Clear</a> is essential reading. Also on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
 <div class="cta"><p style="margin-bottom:16px;font-size:1.05rem">Get weekly mindset fuel delivered to your inbox</p><a href="/subscribe.html">Subscribe Free</a></div>
 </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>
       <p>Continue with the <a href="/category-mindset-resilience.html">Mindset and Resilience</a> collection or read one of these related articles:</p>

--- a/blog/convex-decisions.html
+++ b/blog/convex-decisions.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/creative-confidence.html
+++ b/blog/creative-confidence.html
@@ -142,6 +142,15 @@
             <p>Creative confidence, once rebuilt, requires ongoing maintenance. The evaluative pressure of professional and social environments is constant, and it degrades creative confidence unless you actively counteract it. A few protective practices: maintain a private creative output separate from your professional or public-facing work, where the only standard is your own engagement; curate your inputs carefully, spending less time consuming media that makes you feel inadequate and more time consuming work that genuinely inspires you; and schedule regular creative play &mdash; making things for the pleasure of making, with no output goal.</p>
 
             <p>The most important protection is the ongoing reframe: your value as a person is entirely separable from the quality of any given creative output. This is both psychologically true and strategically useful. Creative work requires the willingness to be bad at it publicly, repeatedly, before you are good at it. Anyone unwilling to tolerate that will not generate enough volume to improve. Separating self-worth from creative evaluation is not just healthy &mdash; it is a prerequisite for creative growth.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/criticism-handling.html
+++ b/blog/criticism-handling.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to protect your attention, health, and relationships. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/daily-mastery.html
+++ b/blog/daily-mastery.html
@@ -112,6 +112,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>George Leonard's <a href="https://www.amazon.com/dp/0452267560?tag=mq061-20" rel="noopener sponsored">Mastery: The Keys to Success and Long-Term Fulfillment</a> is the clearest and most motivating treatment of the mastery path available. Also on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a> — a perfect listen for a morning run or commute.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/daily-rituals-of-successful-people.html
+++ b/blog/daily-rituals-of-successful-people.html
@@ -118,6 +118,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/decision-fatigue.html
+++ b/blog/decision-fatigue.html
@@ -132,6 +132,15 @@
                     <li>Which behaviors I care about most am I treating as decisions rather than as habits?</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/deep-focus.html
+++ b/blog/deep-focus.html
@@ -109,6 +109,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>Cal Newport's <a href="https://www.amazon.com/dp/1455586692?tag=mq061-20" rel="noopener sponsored"><em>Deep Work: Rules for Focused Success in a Distracted World</em></a> is the essential text on this subject — rigorous, practical, and compelling. Available as an audiobook on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a> if you prefer to listen during walks or commutes.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/deep-reading.html
+++ b/blog/deep-reading.html
@@ -142,6 +142,15 @@
                     <li><strong>Weekly:</strong> Reread your margin notes from the week. What themes recur? What questions have been answered by subsequent reading? What do you want to follow up on?</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/deep-work-strategies.html
+++ b/blog/deep-work-strategies.html
@@ -148,6 +148,15 @@
                     <li>Shallow work should be scheduled explicitly, not allowed to expand into unstructured time. Fixed-schedule productivity and email batching are the most effective containment strategies.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/defaults-power.html
+++ b/blog/defaults-power.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to turn scattered effort into visible progress. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/delayed-gratification.html
+++ b/blog/delayed-gratification.html
@@ -79,6 +79,15 @@
 <p>Visualize your future self. What do you want that person to have? What will they thank you for?</p>
 
 <p>Delayed gratification isn't about suffering now for rewards later—it's about making strategic choices that your future self will thank you for.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/deliberate-practice.html
+++ b/blog/deliberate-practice.html
@@ -143,6 +143,15 @@
                     <li><strong>Time limit:</strong> The session ends after 60–90 minutes regardless of how it feels. More practice time is not better; it is usually worse.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/dopamine-detox.html
+++ b/blog/dopamine-detox.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to turn scattered effort into visible progress. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/dopamine-management.html
+++ b/blog/dopamine-management.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to turn scattered effort into visible progress. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/elite-focus.html
+++ b/blog/elite-focus.html
@@ -108,6 +108,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>Cal Newport's <a href="https://www.amazon.com/dp/1455586692?tag=mq061-20" rel="noopener sponsored"><em>Deep Work: Rules for Focused Success in a Distracted World</em></a> is the definitive guide to building elite concentration in a professional context — essential reading for anyone serious about peak performance. Also available as an audiobook on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/embracing-uncertainty.html
+++ b/blog/embracing-uncertainty.html
@@ -111,6 +111,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/emotional-intelligence.html
+++ b/blog/emotional-intelligence.html
@@ -142,6 +142,15 @@
             </div>
 
             <p>The development of emotional intelligence is slow and nonlinear — meaningful progress is visible over months and years, not weeks. The feedback loops are also indirect: you rarely receive clear confirmation that a specific interaction went better because your EI has improved. This makes deliberate practice more important, not less: without a systematic approach, the skill develops haphazardly rather than purposefully. Find additional tools on our <a href="../resources.html">resources page</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/emotional-regulation.html
+++ b/blog/emotional-regulation.html
@@ -142,6 +142,15 @@
                     <li><strong>Evening (5–10 min):</strong> Name three specific emotions from the day. Note one regulatory success (a pause you took, a reappraisal that helped). Note one point where you wish you'd done differently — and visualize the better response you'd give next time.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/energy-rhythm.html
+++ b/blog/energy-rhythm.html
@@ -112,6 +112,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>Matthew Walker's <a href="https://www.amazon.com/dp/1501144316?tag=mq061-20" rel="noopener sponsored">Why We Sleep</a> is the most comprehensive and readable treatment of how sleep and energy rhythms govern human performance — essential reading for anyone serious about sustainable peak performance. Also available on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/environment-cleanup.html
+++ b/blog/environment-cleanup.html
@@ -135,6 +135,15 @@
                     <li><strong>Week 4 — Reintroduce:</strong> Bring back only the services that pass the value test, on your schedule and on your terms.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/envy-elimination.html
+++ b/blog/envy-elimination.html
@@ -125,6 +125,15 @@
                     <li><strong>Use the gratitude antidote.</strong> Name three specific things in your own life that you genuinely value — not to deny the want, but to restore attentional balance.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/ergodicity.html
+++ b/blog/ergodicity.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/essentialism-in-practice.html
+++ b/blog/essentialism-in-practice.html
@@ -135,6 +135,15 @@
                     <li>Remove your single biggest bottleneck so the essential flows with less friction</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/exercise-brain.html
+++ b/blog/exercise-brain.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/expert-learning.html
+++ b/blog/expert-learning.html
@@ -153,6 +153,15 @@
                     <li>Rest and sleep are part of the method—they consolidate what practice builds</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/failure-embracing.html
+++ b/blog/failure-embracing.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/fear-of-failure.html
+++ b/blog/fear-of-failure.html
@@ -89,6 +89,15 @@
 <p>Avoiding failure means avoiding risk, which means avoiding growth. The person who never tries never fails—but also never achieves anything meaningful. The fear of failure becomes a self-fulfilling prophecy: by avoiding failure, you guarantee you won't succeed.</p>
 
 <p>Begin treating failure as feedback. Each "failure" is information pointing toward what might work. The path to success is paved with failures—you just learn to see them differently.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/fear-of-success.html
+++ b/blog/fear-of-success.html
@@ -137,6 +137,15 @@
                     <li>Mindfulness practice builds the self-observation capacity to catch upper-limit behaviors before they execute, creating space for choice rather than automatic avoidance.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/fear-setting.html
+++ b/blog/fear-setting.html
@@ -116,6 +116,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/feedback-loops.html
+++ b/blog/feedback-loops.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to turn scattered effort into visible progress. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/finding-purpose-after-failure.html
+++ b/blog/finding-purpose-after-failure.html
@@ -107,6 +107,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/first-principles.html
+++ b/blog/first-principles.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to turn scattered effort into visible progress. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/flow-focus.html
+++ b/blog/flow-focus.html
@@ -110,6 +110,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>Mihaly Csikszentmihalyi's <a href="https://www.amazon.com/dp/0061339202?tag=mq061-20" rel="noopener sponsored"><em>Flow: The Psychology of Optimal Experience</em></a> is the foundational text — dense with research but deeply readable. For a more tactical application to modern work, Steven Kotler's <em>The Art of Impossible</em> is the best practical companion. Both are available as audiobooks on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/flow-growth.html
+++ b/blog/flow-growth.html
@@ -107,6 +107,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>Mihaly Csikszentmihalyi's foundational <a href="https://www.amazon.com/dp/0061339202?tag=mq061-20" rel="noopener sponsored"><em>Flow: The Psychology of Optimal Experience</em></a> remains the definitive text on using flow for a richer, more meaningful life. Also available as an audiobook on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/flow-habits.html
+++ b/blog/flow-habits.html
@@ -109,6 +109,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>James Clear's <a href="https://www.amazon.com/dp/0735211299?tag=mq061-20" rel="noopener sponsored"><em>Atomic Habits: An Easy &amp; Proven Way to Build Good Habits &amp; Break Bad Ones</em></a> is the most practical guide to the habit installation process that makes flow habits stick. Also available on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/flow-learning.html
+++ b/blog/flow-learning.html
@@ -111,6 +111,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>For the definitive exploration of flow science, <a href="https://www.amazon.com/dp/0061339202?tag=mq061-20" rel="noopener sponsored"><em>Flow: The Psychology of Optimal Experience</em> by Mihaly Csikszentmihalyi</a> is the foundational text. Also available as an audiobook on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/flow-mastery.html
+++ b/blog/flow-mastery.html
@@ -112,6 +112,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>Csikszentmihalyi's original research is captured in <a href="https://www.amazon.com/dp/0061339202?tag=mq061-20" rel="noopener sponsored"><em>Flow: The Psychology of Optimal Experience</em></a> — still the most rigorous and inspiring account of the science. Also available on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a> for commute listening.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/flow-progress.html
+++ b/blog/flow-progress.html
@@ -110,6 +110,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>To go deeper on the science of motivation and progress, <a href="https://www.amazon.com/dp/0307474259?tag=mq061-20" rel="noopener sponsored"><em>Drive: The Surprising Truth About What Motivates Us</em> by Daniel H. Pink</a> is essential. Also available as an audiobook on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/flow-state-triggers.html
+++ b/blog/flow-state-triggers.html
@@ -145,6 +145,15 @@
                     <li>Flow frequency is trainable: people who systematically engineer the triggering conditions report accessing flow several times per week rather than once or twice per month.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/flow-states.html
+++ b/blog/flow-states.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to turn scattered effort into visible progress. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/flow-success.html
+++ b/blog/flow-success.html
@@ -109,6 +109,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>Steven Kotler's <a href="https://www.amazon.com/dp/006312705X?tag=mq061-20" rel="noopener sponsored"><em>The Art of Impossible</em></a> is the most practical modern guide to channeling peak states into ambitious achievement. Available as an audiobook on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a> — Kotler narrates it himself.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/flow-thinking.html
+++ b/blog/flow-thinking.html
@@ -109,6 +109,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>For a rigorous examination of how flow thinking underlies peak performance, <a href="https://www.amazon.com/dp/1491923199?tag=mq061-20" rel="noopener sponsored"><em>The Rise of Superman</em> by Steven Kotler</a> is the definitive modern text. Also available as an audiobook on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/focus-architecture.html
+++ b/blog/focus-architecture.html
@@ -107,6 +107,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>Cal Newport's <a href="https://www.amazon.com/dp/1455586692?tag=mq061-20" rel="noopener sponsored">Deep Work: Rules for Focused Success in a Distracted World</a> is the foundational text on this subject and remains the most rigorous and practical guide to building a focus-optimized life. His follow-up <a href="https://www.amazon.com/dp/0525536515?tag=mq061-20" rel="noopener sponsored">Digital Minimalism</a> addresses the digital architecture layer in depth. Both are available on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/focus-blocks.html
+++ b/blog/focus-blocks.html
@@ -112,6 +112,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>Cal Newport's <a href="https://www.amazon.com/dp/1455586692?tag=mq061-20" rel="noopener sponsored"><em>Deep Work: Rules for Focused Success in a Distracted World</em></a> is the definitive text on building a focus-block practice in a modern professional context. Also available on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/focus-daily.html
+++ b/blog/focus-daily.html
@@ -107,6 +107,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>Cal Newport's <a href="https://www.amazon.com/dp/1455586692?tag=mq061-20" rel="noopener sponsored"><em>Deep Work: Rules for Focused Success in a Distracted World</em></a> provides the most comprehensive treatment of daily focused practice as a professional and life strategy. Also available as an audiobook on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/focus-deep-work.html
+++ b/blog/focus-deep-work.html
@@ -82,6 +82,15 @@
 <p>Knowing you only need to focus for 90 minutes makes starting easier. Extend later if able.</p>
 
 <p>The ability to focus deeply is trainable. Start with small sessions and gradually extend. Your brain will adapt.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/focus-mastery.html
+++ b/blog/focus-mastery.html
@@ -111,6 +111,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>The most rigorous treatment of focus as a professional skill is <a href="https://www.amazon.com/dp/1455586692?tag=mq061-20" rel="noopener sponsored"><em>Deep Work: Rules for Focused Success in a Distracted World</em> by Cal Newport</a>. Also available on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/focus-scheduling.html
+++ b/blog/focus-scheduling.html
@@ -145,6 +145,15 @@
                     <li><strong>Buffer blocks:</strong> One 60-minute unscheduled slot each afternoon for overflow, unexpected priorities, and genuine emergencies.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/goal-setting-science.html
+++ b/blog/goal-setting-science.html
@@ -93,6 +93,15 @@
 
 <h2>The Goal-Setting Process</h2>
 <p>Effective goal pursuit involves: choosing goals that genuinely matter to you, breaking them into actionable steps, creating feedback systems, anticipating obstacles, and adjusting based on results. Goals are hypotheses about what will create progress—test them and iterate.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/gratitude-practice.html
+++ b/blog/gratitude-practice.html
@@ -78,6 +78,15 @@
 <p>Avoid common mistakes that can undermine your gratitude practice, such as lack of consistency or superficiality.</p>
 
 <p>Gratitude is a skill. Like any skill, it improves with practice. The more you look for things to appreciate, the more you'll find.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/growth-architecture.html
+++ b/blog/growth-architecture.html
@@ -107,6 +107,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>For a deep dive into designing systems for automatic behavior change, <a href="https://www.amazon.com/dp/0735211299?tag=mq061-20" rel="noopener sponsored">Atomic Habits by James Clear</a> is the definitive practical guide. Also available as an audiobook on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/growth-mastery.html
+++ b/blog/growth-mastery.html
@@ -178,6 +178,15 @@
                     <li>Develop psychological awareness around resistance—discomfort at the edge of ability is the signal, not the obstacle</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/growth-mindset-habits.html
+++ b/blog/growth-mindset-habits.html
@@ -104,6 +104,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/growth-rhythm.html
+++ b/blog/growth-rhythm.html
@@ -111,6 +111,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>For the definitive framework on managing energy rather than time in pursuit of sustained growth, <a href="https://www.amazon.com/dp/0743226755?tag=mq061-20" rel="noopener sponsored"><em>The Power of Full Engagement</em> by Jim Loehr and Tony Schwartz</a> is essential reading. Also available as an audiobook on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/growth-vs-fixed-mindset.html
+++ b/blog/growth-vs-fixed-mindset.html
@@ -85,6 +85,15 @@
 
 <h2>The Practical Application</h2>
 <p>Mindset isn't just about thinking positively. It's about choosing strategies that lead to learning and growth, even when results are disappointing. A growth mindset doesn't mean you can do anything—it means you can develop capabilities you don't currently have.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/habit-design.html
+++ b/blog/habit-design.html
@@ -113,6 +113,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>For the definitive practical guide to habit design, <a href="https://www.amazon.com/dp/0735211299?tag=mq061-20" rel="noopener sponsored">Atomic Habits by James Clear</a> is the clearest, most actionable book on the subject. BJ Fogg's <a href="https://www.amazon.com/dp/0358003326?tag=mq061-20" rel="noopener sponsored">Tiny Habits</a> offers a complementary approach focused on celebration and celebration science. Both are available as audiobooks on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a> if you prefer to learn while commuting or exercising.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/habit-mastery.html
+++ b/blog/habit-mastery.html
@@ -113,6 +113,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>To go deeper on habit formation, <a href="https://www.amazon.com/dp/0735211299?tag=mq061-20" rel="noopener sponsored"><em>Atomic Habits</em> by James Clear</a> is essential reading. The audiobook version is also available on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a> if you prefer to learn on the go.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/habit-renewal.html
+++ b/blog/habit-renewal.html
@@ -150,6 +150,15 @@
             <p>The most resilient habit practitioners don't just rebuild habits after they collapse &mdash; they audit their habit systems on a scheduled basis, before decay sets in. A quarterly habit review, conducted when habits are still functioning, can catch early signs of reward dilution or identity drift and allow for minor adjustments that prevent full collapse.</p>
 
             <p>A useful quarterly habit audit asks three questions for each major habit: Is this still producing the result it was designed to produce? Is it still aligned with who I am and who I am becoming? Does the current version represent the right level of challenge? Habits that fail any of these tests get updated, not abandoned. Treating renewal as normal rather than as a response to failure removes the shame that often accompanies recognizing that a habit has decayed. All habits decay. The question is whether you catch it early.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/habit-stacking.html
+++ b/blog/habit-stacking.html
@@ -51,6 +51,15 @@
             <h1>Habit Stacking: Linking New Behaviors to Existing Routines</h1>
             <p class="lead">Link new habits to existing ones for automatic follow-through.</p>
             <p> BJ Fogg's insight: existing habits provide reliable cues. Attach new behaviors to established routines for automatic execution.</p><h2>The Stacking Principle</h2><p>After I [current habit], I will [new habit]. This formula leverages existing neural pathways instead of creating new cues from scratch.</p><blockquote>After I [existing habit], I will [new habit].</blockquote><h2>What Is Habit Stacking</h2><p>Habit stacking is a technique used to build new habits by linking them to existing ones.</p><h2>The BJ Fogg Tiny Habits Model</h2><p>The Tiny Habits model, developed by BJ Fogg, provides a framework for creating new habits.</p><h2>Building Your First Stack</h2><ul><li><strong>Map your routine</strong>: Identify reliable anchors</li><li><strong>Start small</strong>: Tiny new behaviors</li><li><strong>Be specific</strong>: Exact actions, exact times</li><li><strong>Stack sequentially</strong>: Multiple new habits possible</li></ul><h2>10 Ready-Made Stacks to Try</h2><ul><li><strong>Morning routine</strong>: Stack a new habit onto your morning coffee or exercise routine</li><li><strong>Evening routine</strong>: Stack a new habit onto your evening reading or meditation routine</li></ul><h2>Tracking Your Stack</h2><p>Use a habit tracker or journal to monitor your progress and identify areas for improvement.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/habit-triggers.html
+++ b/blog/habit-triggers.html
@@ -51,6 +51,15 @@
             <h1>The Science of Habit Triggers</h1>
             <p class="lead">Every habit has a trigger. Understanding cues is the first step to changing any behavior.</p>
             <p>Habits don't happen in a vacuum. They're triggered by specific cues in your environment. Understanding these triggers is essential for both building good habits and breaking bad ones.</p><h2>The Cue-Routine-Reward Loop</h2><p>Your brain is always looking for patterns—situations that predict rewards. These patterns become triggers that automatically initiate behaviors. The coffee cup triggers the morning pour. The phone buzzes triggers the reach.</p><blockquote>Identify the trigger, change the habit.</blockquote><h2>Finding Your Triggers</h2><ul><li><strong>Time-based</strong>: Certain times of day trigger routines</li><li><strong>Location-based</strong>: Places cue specific behaviors</li><li><strong>Emotional states</strong>: Feelings trigger coping behaviors</li><li><strong>Preceding events</strong>: One action leads to another</li></ul><p>Map your habits. Identify what triggers each one. Then design your environment accordingly.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/how-to-build-a-morning-routine.html
+++ b/blog/how-to-build-a-morning-routine.html
@@ -138,6 +138,15 @@ navigator a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/how-to-build-self-confidence.html
+++ b/blog/how-to-build-self-confidence.html
@@ -89,6 +89,15 @@ navigator a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <a href="/subscribe.html" class="beehiiv-subscribe-button">Subscribe Now</a>
     </div>
   </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/how-to-develop-grit.html
+++ b/blog/how-to-develop-grit.html
@@ -109,6 +109,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/how-to-set-and-achieve-goals.html
+++ b/blog/how-to-set-and-achieve-goals.html
@@ -100,6 +100,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/how-to-stay-motivated-long-term.html
+++ b/blog/how-to-stay-motivated-long-term.html
@@ -131,6 +131,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/how-to-stop-overthinking.html
+++ b/blog/how-to-stop-overthinking.html
@@ -114,6 +114,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/hyper-growth.html
+++ b/blog/hyper-growth.html
@@ -108,6 +108,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>Josh Waitzkin's <a href="https://www.amazon.com/dp/0743277465?tag=mq061-20" rel="noopener sponsored"><em>The Art of Learning</em></a> is the most insightful account of how genuine mastery is built — from a chess prodigy and world champion martial artist who has thought deeply about the mechanics of rapid development. Available on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/identity-based-habits.html
+++ b/blog/identity-based-habits.html
@@ -79,6 +79,15 @@
 <p>Becoming new means releasing old labels. "I was always bad at math" becomes "I'm someone who's learning math."</p>
 
 <p>When habits align with identity, motivation becomes unnecessary. You do these things because that's who you are.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/identity-shift.html
+++ b/blog/identity-shift.html
@@ -143,6 +143,15 @@
                     <li><strong>Day 22–30:</strong> Review the evidence accumulated. Count the votes. Notice how the identity feels more natural than on Day 1. Plan the next 30-day cycle.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/ikigai-finding-purpose.html
+++ b/blog/ikigai-finding-purpose.html
@@ -167,6 +167,15 @@
                     <li>The five pillars of daily ikigai (Mogi): start small, accept yourself, connect with others, seek small joys, and be in the here and now. Less dramatic than purpose-finding frameworks usually promise, but far more reliably achievable.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/implementation-intentions.html
+++ b/blog/implementation-intentions.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to turn scattered effort into visible progress. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/imposter-syndrome.html
+++ b/blog/imposter-syndrome.html
@@ -74,6 +74,15 @@
 
             <h2>When to Seek Outside Perspective</h2>
             <p>While self-help strategies are invaluable, sometimes managing imposter syndrome requires an external perspective. Sharing your feelings with trusted mentors, colleagues, or friends can be incredibly validating. You'll often find that many accomplished individuals secretly harbor similar doubts, normalizing your experience. Beyond informal support, consider seeking professional guidance from a therapist or coach. A mental health professional can provide tailored strategies, help you explore underlying causes of your self-doubt, and teach you cognitive behavioral techniques to reframe your thoughts more effectively. They can offer an objective viewpoint and equip you with tools to build lasting self-compassion and confidence, ensuring that you truly own your achievements rather than constantly questioning them.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/inconvenience-yourself.html
+++ b/blog/inconvenience-yourself.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/infinite-learning.html
+++ b/blog/infinite-learning.html
@@ -145,6 +145,15 @@
                     <li><strong>Quarterly:</strong> Review your question log from the past three months. Which questions were you unable to answer at the time and haven't addressed yet? These represent the blindspots worth prioritizing.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/influence-skills.html
+++ b/blog/influence-skills.html
@@ -135,6 +135,15 @@
                 <p>The distinction between ethical influence and manipulation is not about the techniques used — it is about whether those techniques are deployed in service of outcomes that are genuinely good for both parties. Using social proof to help someone make a decision that is actually in their interest is ethical. Manufacturing false social proof to sell a product that will harm them is manipulation. The principles work in both directions. The ethics lie in the intent and the honesty.</p>
                 <p>A useful self-test: would you be comfortable if the person you're trying to influence could see exactly what you're doing and why? If yes, it is almost certainly ethical. If not, that discomfort is diagnostic.</p>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/intentional-living.html
+++ b/blog/intentional-living.html
@@ -125,6 +125,15 @@
                     <li><strong>Direction check:</strong> Is the overall trajectory of this year pointing toward the life I am trying to build? If I continue doing what I'm doing, where do I arrive?</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/inversion-thinking.html
+++ b/blog/inversion-thinking.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/journaling-power.html
+++ b/blog/journaling-power.html
@@ -70,6 +70,15 @@
             <p>The first mistake is using the journal only to vent without reflection. Venting can release pressure, but if every entry ends with the same frustration, add a second step: "What is this showing me?" or "What boundary, conversation, or action would help?" The second mistake is turning journaling into another performance. If you worry about writing beautifully, you may avoid writing honestly.</p>
             <p>A third mistake is making the habit too large. You do not need an hour, special pens, or a perfect morning routine. You need a repeatable practice that helps you think. Finally, avoid reading old entries only to criticize yourself. Review them like data. Look for growth, repeated lessons, and signals about what deserves your attention now.</p>
             <p>Used this way, journaling becomes a quiet form of self-leadership. It helps you pause before reacting, understand yourself before explaining yourself, and choose the next step with more intention.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/learned-optimism.html
+++ b/blog/learned-optimism.html
@@ -138,6 +138,15 @@
                     <li>For people with significant anxiety, learned optimism combined with mindfulness practice produces better outcomes than either alone.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/learning-speed.html
+++ b/blog/learning-speed.html
@@ -72,6 +72,15 @@
             <p>Limit inputs. Too many books, videos, and courses can become avoidance. Choose one or two high-quality sources, extract practice tasks, and spend most of your time applying. For every hour of instruction, aim for multiple hours of doing. Skill grows when knowledge meets repeated action.</p>
             <p>Rest is part of the system too. Sleep, breaks, and recovery help consolidate learning. A tired brain may still consume information, but it struggles to encode and apply it. Sustainable learning balances intensity with recovery.</p>
             <p>Learn like your future depends on it, because in many ways it does. The ability to acquire skills quickly gives you more options, more confidence, and more ways to contribute. Use active methods, seek feedback, and let consistent practice compound.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/learning-stack.html
+++ b/blog/learning-stack.html
@@ -113,6 +113,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>Scott Young's <a href="https://www.amazon.com/dp/006245839X?tag=mq061-20" rel="noopener sponsored">Ultralearning</a> is the best practical guide to accelerated skill acquisition and covers many of these principles in depth. Tiago Forte's <a href="https://www.amazon.com/dp/1982167386?tag=mq061-20" rel="noopener sponsored">Building a Second Brain</a> complements it with a system for managing and retrieving everything you learn. Both are available on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/learning-systems.html
+++ b/blog/learning-systems.html
@@ -108,6 +108,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>Peter Brown, Henry Roediger, and Mark McDaniel's <a href="https://www.amazon.com/dp/0674729013?tag=mq061-20" rel="noopener sponsored">Make It Stick: The Science of Successful Learning</a> is the most readable summary of the cognitive science research on effective learning. Barbara Oakley's <a href="https://www.amazon.com/dp/039916524X?tag=mq061-20" rel="noopener sponsored">A Mind for Numbers</a> applies these principles specifically to technical and difficult subjects. Both available on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/legacy-thinking.html
+++ b/blog/legacy-thinking.html
@@ -138,6 +138,15 @@
                     <li>Legacy is built in daily texture, not grand gestures. A weekly legacy review, a morning frame, and deliberate investment in long-compounding accounts (relationships, health, skills) are the primary practice vehicles.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/lessons-from-stoic-philosophers.html
+++ b/blog/lessons-from-stoic-philosophers.html
@@ -115,6 +115,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/margin-safety.html
+++ b/blog/margin-safety.html
@@ -156,6 +156,15 @@
                     <li>Build conservative assumptions into decisions: ensure failure scenarios are survivable, not just unlikely.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/master-habits.html
+++ b/blog/master-habits.html
@@ -110,6 +110,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>Charles Duhigg's <a href="https://www.amazon.com/dp/081298160X?tag=mq061-20" rel="noopener sponsored"><em>The Power of Habit</em></a> remains one of the most thorough examinations of habit science written for a general audience. It's also available as an audiobook on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a> — ideal listening for a morning walk.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/maximum-focus.html
+++ b/blog/maximum-focus.html
@@ -113,6 +113,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>Cal Newport's <a href="https://www.amazon.com/dp/1455586692?tag=mq061-20" rel="noopener sponsored"><em>Deep Work: Rules for Focused Success in a Distracted World</em></a> is the definitive guide to building the concentration capacity that maximum focus requires. Also available on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/maximum-growth.html
+++ b/blog/maximum-growth.html
@@ -194,6 +194,15 @@
                     <li><strong>Track and reflect</strong> — Review your progress weekly. Compound insight with compound effort.</li>
                 </ol>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/meaning-making.html
+++ b/blog/meaning-making.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to protect your attention, health, and relationships. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/meaningful-work.html
+++ b/blog/meaningful-work.html
@@ -145,6 +145,15 @@
                     <li><strong>Presence:</strong> Are you actually present with your work when you're doing it, or are you mentally elsewhere most of the time?</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/meditation-habits.html
+++ b/blog/meditation-habits.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to protect your attention, health, and relationships. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/mental-contrasting.html
+++ b/blog/mental-contrasting.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/mental-models.html
+++ b/blog/mental-models.html
@@ -140,6 +140,15 @@
                     <li>The payoff is compound: models that integrate into a latticework become more valuable than the sum of their parts. A decade of deliberate model-building produces exceptional judgment.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/meta-learning.html
+++ b/blog/meta-learning.html
@@ -113,6 +113,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>Scott Young's <a href="https://www.amazon.com/dp/0062852922?tag=mq061-20" rel="noopener sponsored"><em>Ultralearning</em></a> is the most practical guide to meta-learning written for a general audience, packed with case studies and actionable strategies. Also available on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/micro-habits.html
+++ b/blog/micro-habits.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/mindful-focus.html
+++ b/blog/mindful-focus.html
@@ -119,6 +119,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>Jon Kabat-Zinn's <a href="https://www.amazon.com/dp/1401307787?tag=mq061-20" rel="noopener sponsored"><em>Wherever You Go, There You Are</em></a> is a classic, accessible introduction to the mindfulness principles that underpin mindful focus — also available on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/mindful-habits.html
+++ b/blog/mindful-habits.html
@@ -149,6 +149,15 @@
                     <li><strong>Add 10 minutes of formal meditation</strong> — morning works best for most people; the quality of attentional training determines the quality of everything else</li>
                 </ol>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/mindful-productivity.html
+++ b/blog/mindful-productivity.html
@@ -99,6 +99,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>For the scientific case for deep, undistracted work, <a href="https://www.amazon.com/dp/1455586692?tag=mq061-20" rel="noopener sponsored">Deep Work by Cal Newport</a> is essential. Pair it with the audiobook on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a> for your commute or gym sessions.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/mindfulness-for-beginners.html
+++ b/blog/mindfulness-for-beginners.html
@@ -110,6 +110,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/minimalism-productivity.html
+++ b/blog/minimalism-productivity.html
@@ -66,6 +66,15 @@
 
             <h2>Signs You're Over-Complicating Your Workflow</h2>
             <p>Sometimes, we're so deep in the weeds of our own complexity that we don't even realize how much we're over-complicating things. Here are some common indicators that you might benefit from embracing minimalism in your workflow: you constantly feel overwhelmed, despite working long hours; you frequently miss deadlines or feel perpetually behind; your physical or digital workspace is cluttered and disorganized; you struggle with decision-making because there are too many options or competing priorities; you find yourself constantly context-switching between tasks without making significant progress on any; or you feel a persistent sense of busyness without a corresponding feeling of accomplishment. Recognizing these signs is the first step toward simplifying your approach and reclaiming your focus and energy.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/monk-mode.html
+++ b/blog/monk-mode.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/morning-pages-for-clarity.html
+++ b/blog/morning-pages-for-clarity.html
@@ -150,6 +150,15 @@
                     <li><strong>Commit to 30 days before evaluating.</strong> The first week is not representative of the practice. Give it a month before deciding whether it's working.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/morning-pages.html
+++ b/blog/morning-pages.html
@@ -51,6 +51,15 @@
             <h1>Morning Pages: The Creative's Secret Weapon</h1>
             <p class="lead">Stream-of-consciousness morning writing clears mental clutter and unlocks creativity.</p>
             <p>Julia Cameron's morning pages: three pages of stream-of-consciousness writing before doing anything else. This practice clears mental debris and often surfaces unexpected creative insights.</p><h2>What Are Morning Pages?</h2><p>Three pages, longhand, first thing in the morning. Don't think—just write. Whatever comes out. It's not for anyone else—it's for clearing your mental cache.</p><blockquote>Write first. Think later.</blockquote><h2>How to Start (Step-by-Step)</h2><p>1. Get a notebook and pen.</p><p>2. Set a timer for 10 minutes.</p><p>3. Write whatever comes to mind without stopping or editing.</p><h2>Benefits After 30 Days</h2><p>After 30 days of consistent morning pages practice, you can expect to see improvements in your mental clarity, creativity, and overall well-being.</p><h2>Tools You Need</h2><p>A notebook and pen are all you need to get started with morning pages.</p><p>For further reading on morning pages, we recommend checking out <a href="https://www.amazon.com/dp/0874779307?tag=YOUR-TAG-20">The Artist's Way</a> by Julia Cameron.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/morning-routines-successful-people.html
+++ b/blog/morning-routines-successful-people.html
@@ -110,6 +110,15 @@
             <p>The real secret isn't copying what successful people do in the morning—it's understanding why they do it and adapting those principles to your life, your biology, and your goals. Experiment, observe results, and iterate. What works for someone else almost certainly won't work exactly the same way for you.</p>
             
             <p>Start small. Pick one element to add to your morning. Keep it for thirty days before evaluating. Then adjust. The perfect morning routine isn't something you find—it's something you build through experimentation and consistency.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/motivation-maintenance.html
+++ b/blog/motivation-maintenance.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/narrative-identity.html
+++ b/blog/narrative-identity.html
@@ -138,6 +138,15 @@
                     <li>A generative narrative produces different behaviors: greater willingness to take meaningful risks, higher persistence through difficulty, and greater orientation toward contribution.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/negative-capability.html
+++ b/blog/negative-capability.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to protect your attention, health, and relationships. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/negative-self-talk.html
+++ b/blog/negative-self-talk.html
@@ -85,6 +85,15 @@
 
 <h2>When to Seek Help</h2>
 <p>Your inner voice became established through repetition. It can change through new repetition. The conversations you have with yourself matter enormously. For more on managing negative self-talk and building self-confidence, check out our article on <a href="/blog/overcoming-self-doubt.html">overcoming self-doubt</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/negative-visualization.html
+++ b/blog/negative-visualization.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to protect your attention, health, and relationships. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/network-effects.html
+++ b/blog/network-effects.html
@@ -137,6 +137,15 @@
                     <li><strong>Early-stage investments:</strong> Are you investing in new relationships at early career stages and in emerging communities, not just established figures in established networks?</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/occams-razor.html
+++ b/blog/occams-razor.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/optionality.html
+++ b/blog/optionality.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/overcoming-imposter-syndrome.html
+++ b/blog/overcoming-imposter-syndrome.html
@@ -107,6 +107,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/overcoming-procrastination.html
+++ b/blog/overcoming-procrastination.html
@@ -100,6 +100,15 @@
               <a href="/subscribe.html" class="beehiiv-subscribe-button">Subscribe Now</a>
             </div>
             <div class="tags"><span class="tag">procrastination</span> <span class="tag">productivity</span> <span class="tag">psychology</span></div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/overcoming-self-doubt.html
+++ b/blog/overcoming-self-doubt.html
@@ -74,6 +74,15 @@ navigator a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/pareto-principle.html
+++ b/blog/pareto-principle.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to turn scattered effort into visible progress. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/parkinsons-law.html
+++ b/blog/parkinsons-law.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to turn scattered effort into visible progress. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/perfectionism-recovery.html
+++ b/blog/perfectionism-recovery.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to protect your attention, health, and relationships. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/performance-optimization.html
+++ b/blog/performance-optimization.html
@@ -62,6 +62,15 @@
 <h2>Further Reading</h2><p>For the science of peak performance, <a href="https://www.amazon.com/dp/0544947223?tag=mq061-20" rel="noopener sponsored">Peak by Anders Ericsson</a> is the definitive text on deliberate practice and expert performance. Available on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
 <div class="cta"><p style="margin-bottom:16px;font-size:1.05rem">Get weekly mindset fuel delivered to your inbox</p><a href="/subscribe.html">Subscribe Free</a></div>
 </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>
       <p>Continue with the <a href="/category-mindset-resilience.html">Mindset and Resilience</a> collection or read one of these related articles:</p>

--- a/blog/positive-environment.html
+++ b/blog/positive-environment.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to protect your attention, health, and relationships. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/post-traumatic-growth-science.html
+++ b/blog/post-traumatic-growth-science.html
@@ -145,6 +145,15 @@
                     <li>Not everyone experiences PTG, and its absence does not indicate failure &mdash; recovery alone is meaningful and valuable</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/post-traumatic-growth.html
+++ b/blog/post-traumatic-growth.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/power-of-consistency.html
+++ b/blog/power-of-consistency.html
@@ -81,6 +81,15 @@
 </ul>
 
 <p>The magic isn't in any single action—it's in the accumulation. Show up, do the work, repeat. That's the entire secret.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/power-of-deliberate-practice.html
+++ b/blog/power-of-deliberate-practice.html
@@ -89,6 +89,15 @@
 </ul>
 
 <p>The path to mastery isn't mysterious. It's systematic, focused, often uncomfortable work. But it's available to anyone willing to put in the quality practice.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/power-of-gratitude-journaling.html
+++ b/blog/power-of-gratitude-journaling.html
@@ -114,6 +114,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to protect your attention, health, and relationships. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/pressure-performance.html
+++ b/blog/pressure-performance.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to protect your attention, health, and relationships. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/productive-procrastination.html
+++ b/blog/productive-procrastination.html
@@ -62,6 +62,15 @@
 <h2>Further Reading</h2><p>For a research-backed deep dive on procrastination, <a href="https://www.amazon.com/dp/0061703966?tag=mq061-20" rel="noopener sponsored">The Procrastination Equation by Piers Steel</a> is the most rigorous treatment available. On <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a> too.</p>
 <div class="cta"><p style="margin-bottom:16px;font-size:1.05rem">Get weekly mindset fuel delivered to your inbox</p><a href="/subscribe.html">Subscribe Free</a></div>
 </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>
       <p>Continue with the <a href="/category-productivity-focus.html">Productivity and Focus</a> collection or read one of these related articles:</p>

--- a/blog/productive-solitude.html
+++ b/blog/productive-solitude.html
@@ -132,6 +132,15 @@
             </ol>
 
             <p>For more on how solitude fits into a broader approach to recovery and sustainable performance, see our guide to <a href="/blog/rest-as-strategy.html">rest as strategy</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/progress-principle.html
+++ b/blog/progress-principle.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/purpose-discovery.html
+++ b/blog/purpose-discovery.html
@@ -71,6 +71,15 @@
             <p>Ask three practical questions each morning: "What matters today?", "Who can I serve or strengthen?", and "What action would make future me grateful?" These questions translate purpose into behavior. They keep the idea from floating above your life as an inspirational slogan.</p>
             <p>Purpose can also change. A season focused on building stability may give way to a season focused on contribution. A role that once fit may become too small. Evolution is not failure. It is evidence that you are alive and paying attention.</p>
             <p>Stop waiting for perfect certainty. Choose a meaningful direction, take the next honest step, and let life give you feedback. Purpose is discovered partly by reflection, but it is built by action.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/quantum-growth.html
+++ b/blog/quantum-growth.html
@@ -179,6 +179,15 @@
                     <li><strong>Measure leading indicators</strong> — what process metrics predict the performance breakthrough you're working toward?</li>
                 </ol>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/radical-ownership.html
+++ b/blog/radical-ownership.html
@@ -110,6 +110,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/reading-habit.html
+++ b/blog/reading-habit.html
@@ -146,6 +146,15 @@
             <p>A persistent question for anyone building a reading habit is whether audiobooks count. The research suggests that the answer is mostly yes. Studies comparing reading and listening for comprehension and retention generally find comparable results for narrative and expository text, with print showing modest advantages for dense technical material where re-reading and slowing down are important. For most books — narrative nonfiction, biography, business, personal development — listening at moderate speed produces similar comprehension to reading.</p>
 
             <p>The practical implication is that audiobooks are a powerful supplement to physical reading, particularly for contexts where reading text is not possible. A service like <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a> effectively converts otherwise-lost time into reading time. The person who listens during a forty-minute daily commute adds roughly 200 hours of reading time per year — fifteen to twenty additional books — without changing anything else about their schedule. This is one of the single most high-leverage changes most people can make to their annual book count. It connects naturally with the <a href="/blog/deep-reading.html">deep reading</a> practices that maximize how much you absorb from any given session.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/regret-minimization.html
+++ b/blog/regret-minimization.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/resilience-building.html
+++ b/blog/resilience-building.html
@@ -85,6 +85,15 @@
 </ul>
 
 <p>For a deeper dive into resilience and post-traumatic growth, consider <a href="https://www.amazon.com/dp/1524763422?tag=mq061-20" rel="noopener sponsored"><em>Option B</em></a> by Sheryl Sandberg.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/rest-as-strategy.html
+++ b/blog/rest-as-strategy.html
@@ -154,6 +154,15 @@
                     <li><strong>Use meditation as attentional recovery</strong> — even 10 minutes restores focus capacity meaningfully</li>
                 </ol>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/rest-recovery.html
+++ b/blog/rest-recovery.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to protect your attention, health, and relationships. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/reversible-decisions.html
+++ b/blog/reversible-decisions.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/risk-appetite.html
+++ b/blog/risk-appetite.html
@@ -182,6 +182,15 @@
                     <li>Tolerance for uncertainty is a learnable skill that compounds: expanding your comfortable envelope expands the range of opportunities available to you.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/robust-mindset.html
+++ b/blog/robust-mindset.html
@@ -156,6 +156,15 @@
                     <li>Rest is a component of robustness, not a break from it</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/saying-no.html
+++ b/blog/saying-no.html
@@ -74,6 +74,15 @@
 
             <h2>Handling Pushback Gracefully</h2>
             <p>Even with the best intentions and polite refusals, you might encounter pushback. Some people may not easily accept a 'no,' or they might try to persuade you. In these situations, the key is to remain calm, reiterate your boundary, and avoid getting drawn into lengthy explanations or justifications. You can say, "I understand, but my decision remains the same," or "I've considered it, and I won't be able to commit." If appropriate and you genuinely wish to, you can offer a limited alternative ("I can't do X, but I could help with Y for 15 minutes"), but only if it doesn't compromise your boundaries. Remember, you are not responsible for managing someone else's reaction to your boundaries. Gracefully holding your ground reinforces your self-respect and teaches others how to treat your time.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/scarcity-abundance.html
+++ b/blog/scarcity-abundance.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/second-order-thinking.html
+++ b/blog/second-order-thinking.html
@@ -128,6 +128,15 @@
                     <li><strong>Step 6:</strong> Does the second-order analysis change the decision? If yes, update. If the uncertainty is too high to update, stop and decide on the available information.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/self-awareness-practice.html
+++ b/blog/self-awareness-practice.html
@@ -123,6 +123,15 @@
                     <li><strong>Quarterly:</strong> Review journal entries for recurring patterns. What triggers consistently produce the same response? Where does your behavior most diverge from your intentions?</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/self-compassion-science.html
+++ b/blog/self-compassion-science.html
@@ -132,6 +132,15 @@
                     <li>Mindfulness is the foundation. A regular practice builds early detection of self-critical spirals, which is when they are most amenable to intervention.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/self-discipline-mastery.html
+++ b/blog/self-discipline-mastery.html
@@ -91,6 +91,15 @@
 </ul>
 
 <p>Self-discipline mastered isn't about gritting your teeth through resistance—it's about building a life where the right choices are the easy choices.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/self-efficacy.html
+++ b/blog/self-efficacy.html
@@ -130,6 +130,15 @@
                     <li><strong>Build a pre-performance state management routine.</strong> Even five minutes of focused breathing and a brief review of past successes before any performance that matters.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/skill-stacking-career.html
+++ b/blog/skill-stacking-career.html
@@ -130,6 +130,15 @@
             <p>The other critical element of skill stacking is the ability to learn new skills faster than average&mdash;because you are trying to develop competence in several domains rather than just one. This points directly to the learning strategies that accelerate acquisition: active recall over passive review, spaced repetition to combat forgetting, deliberate practice on specific weaknesses rather than comfortable repetition of strengths, and finding mentors who have already made the mistakes you would otherwise make.</p>
 
             <p>Audiobooks and podcasts can be legitimate tools for initial orientation in a new domain&mdash;<a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>'s library covers business, psychology, leadership, technology, and many other skill-relevant domains with high-quality titles that can accelerate the conceptual foundation-building phase of learning a new area. But passive consumption needs to be followed by active application: teaching, writing, building, and getting feedback on real work. The combination of these two phases is where genuine skill develops. For the research on this, see our article on <a href="/blog/active-recall-learning.html">active recall learning</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/skin-in-game.html
+++ b/blog/skin-in-game.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/sleep-performance.html
+++ b/blog/sleep-performance.html
@@ -89,6 +89,15 @@
 <p>Caffeine has a half-life of 5-6 hours. That afternoon coffee is still 50% active at 9 PM if you consumed it at 3 PM.</p>
 
 <p>Optimizing sleep isn't lazy—it's smart. Your cognitive and emotional capacity depends on it.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/social-proof.html
+++ b/blog/social-proof.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to build trust without performing or forcing it. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/social-support.html
+++ b/blog/social-support.html
@@ -70,6 +70,15 @@
             <p>Friends and family are important, but some situations require trained help. If you are dealing with persistent depression, anxiety, trauma, addiction, thoughts of self-harm, unsafe relationships, or stress that is disrupting daily life, professional support is appropriate. A therapist, counselor, physician, coach, or support group can provide structure and expertise that personal relationships cannot always offer.</p>
             <p>Seeking help is not a failure of strength. It is a wise use of resources. The goal is not to outsource your life; it is to build enough stability and skill that you can participate in your life more fully. Strong people ask for support before isolation hardens into a habit.</p>
             <p>Your network is one of your most important growth environments. Invest in relationships that stretch you, steady you, and help you become someone who can offer the same strength back.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/spaced-repetition-learning.html
+++ b/blog/spaced-repetition-learning.html
@@ -137,6 +137,15 @@
                     <li><strong>Month 2 and beyond:</strong> Add new domains, connect related material across domains, and begin to notice the cross-domain pattern recognition that a multi-domain spaced repetition practice enables over time.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/stoic-morning-routine.html
+++ b/blog/stoic-morning-routine.html
@@ -83,6 +83,15 @@ navigator a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/storytelling-success.html
+++ b/blog/storytelling-success.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to build trust without performing or forcing it. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/stress-management.html
+++ b/blog/stress-management.html
@@ -72,6 +72,15 @@
 <h2>Quick Wins: Start Today</h2>
 <p>(1) Spend five minutes writing a brief stress audit: list your top three stressors and mark each as controllable, influenceable, or uncontrollable. (2) Schedule your recovery practice tomorrow — even 10 minutes of walking counts. (3) Create a simple end-of-work transition ritual for today: close your laptop, write tomorrow's single top priority, and do two minutes of slow breathing before you move on.</p>
 <div style="background:#4f46e5;color:white;padding:25px;border-radius:12px;text-align:center;margin:25px 0"><a href="/subscribe.html" style="background:white;color:#4f46e5;padding:12px 24px;border-radius:25px;text-decoration:none;font-weight:600;">Subscribe Free</a></div></div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>
       <p>Continue with the <a href="/category-mindset-resilience.html">Mindset and Resilience</a> collection or read one of these related articles:</p>

--- a/blog/stress-relief.html
+++ b/blog/stress-relief.html
@@ -27,6 +27,15 @@
 <h2>Quick Wins: Start Today</h2>
 <p>(1) Try the physiological sigh right now — double inhale through the nose, long exhale through the mouth. Notice the shift. (2) Schedule a 10-minute walk today, preferably outside. Don't multitask — just walk. (3) Identify your one biggest recurring stressor and write down one specific action you could take this week to reduce it by even 10%.</p>
 <div style="background:#4f46e5;color:white;padding:25px;border-radius:12px;text-align:center;margin:25px 0"><a href="/subscribe.html" style="background:white;color:#4f46e5;padding:12px 24px;border-radius:25px;text-decoration:none;font-weight:600;">Subscribe Free</a></div></div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>
       <p>Continue with the <a href="/category-mindset-resilience.html">Mindset and Resilience</a> collection or read one of these related articles:</p>

--- a/blog/sunk-cost.html
+++ b/blog/sunk-cost.html
@@ -81,6 +81,15 @@
 
             <h2>Reframing 'Loss' as 'Learning'</h2>
             <p>One of the most powerful ways to overcome the emotional hurdle of the sunk cost fallacy is to reframe the concept of 'loss.' Instead of viewing the abandonment of a project, relationship, or career path as a failure or a waste of past investment, see it as a valuable learning experience. Every decision, even those that don't pan out, provides insights into what works, what doesn't, and what you truly value. Cutting your losses isn't about admitting defeat; it's about demonstrating good judgment, adaptability, and the courage to pivot towards more promising ventures. It frees up your most precious resources—time, energy, and mental bandwidth—for opportunities that are genuinely aligned with your future goals. Embrace the idea that every ending is a new beginning, and every 'loss' is a lesson learned that makes you wiser for your next endeavor.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/sustainable-success.html
+++ b/blog/sustainable-success.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/systems-vs-goals.html
+++ b/blog/systems-vs-goals.html
@@ -150,6 +150,15 @@
                     <li>Design for bad days, not good ones. A system that only runs under optimal conditions is a best-case plan. A system that runs on the worst days is a real system.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/temptation-bundling.html
+++ b/blog/temptation-bundling.html
@@ -131,6 +131,15 @@
                     <li><strong>Step 5 — Track for 30 days:</strong> Note whether you looked forward to the bundle, whether you completed the primary task more consistently, and whether the enjoyable element still felt compelling. Adjust as needed.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/the-art-of-letting-go.html
+++ b/blog/the-art-of-letting-go.html
@@ -110,6 +110,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/the-compound-effect-explained.html
+++ b/blog/the-compound-effect-explained.html
@@ -111,6 +111,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/the-growth-mindset-in-practice.html
+++ b/blog/the-growth-mindset-in-practice.html
@@ -136,6 +136,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/the-mindset-of-high-performers.html
+++ b/blog/the-mindset-of-high-performers.html
@@ -103,6 +103,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/the-power-of-solitude.html
+++ b/blog/the-power-of-solitude.html
@@ -116,6 +116,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/the-role-of-boredom-in-creativity.html
+++ b/blog/the-role-of-boredom-in-creativity.html
@@ -145,6 +145,15 @@
                     <li><strong>Clear attention residue first.</strong> Deliberate disengagement from active tasks before boredom periods improves their creative yield.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/the-science-of-gratitude.html
+++ b/blog/the-science-of-gratitude.html
@@ -115,6 +115,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to protect your attention, health, and relationships. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/the-science-of-habit-formation.html
+++ b/blog/the-science-of-habit-formation.html
@@ -177,6 +177,15 @@
             <p>Over weeks and months, this single habit becomes automatic. Then add another. Compound interest applies to habits as surely as it applies to money—the small actions you take consistently create results far beyond what seems possible from any single action.</p>
             
             <p>Your brain is waiting to be rewired. The question isn't whether change is possible—neuroscience proves it is. The question is what habits you'll choose to build, and what identity you'll choose to become.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/the-zeigarnik-effect.html
+++ b/blog/the-zeigarnik-effect.html
@@ -148,6 +148,15 @@
                     <li><strong>Before switching tasks, write the next step</strong> — create a plan for closure to reduce attention residue</li>
                 </ol>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/thought-leadership.html
+++ b/blog/thought-leadership.html
@@ -161,6 +161,15 @@
                     <li>The motivation must be intrinsic — genuine care for the intellectual work itself — because recognition arrives too slowly to sustain effort if it is the primary driver.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/time-management-myths.html
+++ b/blog/time-management-myths.html
@@ -128,6 +128,15 @@
             <p>Strip away the myths and a clearer picture emerges. The people who accomplish the most are not working the most hours, using the most elaborate systems, or possessing the most willpower. They consistently do a small number of important things: they protect their peak energy hours for their most critical work, they minimize task-switching during deep work blocks, they design their environments for focus, and they treat recovery as seriously as work.</p>
 
             <p>At a practical level, this means auditing your week honestly. Where does your best cognitive energy actually go? If the answer is meetings, email, and administrative tasks&mdash;with creative and strategic work crammed into whatever is left&mdash;the schedule is upside down. Protect two to four hours of focused time early in your day, batch reactive work into defined windows, and stop measuring productivity by hours worked or items checked off. Measure it by the quality and impact of the work you actually produce.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/turning-setbacks-into-comebacks.html
+++ b/blog/turning-setbacks-into-comebacks.html
@@ -111,6 +111,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/ultradian-rhythm-productivity.html
+++ b/blog/ultradian-rhythm-productivity.html
@@ -166,6 +166,15 @@
                     <li>Track your energy hourly for one week—your personal data will quickly show your individual rhythm</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/ultralearning.html
+++ b/blog/ultralearning.html
@@ -124,6 +124,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/understanding-motivation.html
+++ b/blog/understanding-motivation.html
@@ -136,6 +136,15 @@
             </ul>
 
             <p>The deepest insight from decades of motivation research is perhaps the simplest: motivation is not a prerequisite for action. It is frequently a consequence of it. Starting a task&mdash;even reluctantly, even with resistance&mdash;typically generates the momentum that sustains it. Waiting until you feel motivated before beginning almost never works. Acting first, and allowing motivation to emerge from engagement, usually does.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/values-clarification.html
+++ b/blog/values-clarification.html
@@ -146,6 +146,15 @@
                     <li>Translate clarified values into specific behavioral commitments; treat the process as an empirical experiment, not a permanent declaration</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/values-living.html
+++ b/blog/values-living.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to protect your attention, health, and relationships. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/via-negativa.html
+++ b/blog/via-negativa.html
@@ -150,6 +150,15 @@
                     <li>Essentialism is via negativa applied at scale: ruthless elimination of the non-essential so that the essential can receive the best of your time and attention rather than what remains after everything else.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/vibrant-growth.html
+++ b/blog/vibrant-growth.html
@@ -145,6 +145,15 @@
                     <li>The goal is growth that generates energy rather than depleting it—that feels alive, not just productive</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/victory-habits.html
+++ b/blog/victory-habits.html
@@ -128,6 +128,15 @@
             <p>Most habit attempts fail for predictable reasons: starting too big, relying on motivation, having no cue, expecting fast results, and&mdash;most commonly&mdash;treating a single missed day as total failure. The antidote to that last trap is a simple rule: never miss twice. One missed day is an accident; two in a row is the beginning of a new, worse habit. Missing once and returning immediately is what consistency actually looks like in real life.</p>
 
             <p>The other quiet killer is perfectionism. People abandon a habit that is working at eighty percent because it is not working at one hundred. But an imperfect habit sustained for a year beats a perfect habit sustained for a week, every single time. For more on bending without breaking, our companion piece on <a href="/blog/atomic-habits-key-lessons.html">the key lessons of Atomic Habits</a> is a useful next read, and you can find curated tools for building better systems on our <a href="../resources.html">resources page</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/visualization-power.html
+++ b/blog/visualization-power.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to protect your attention, health, and relationships. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/wealth-mindset.html
+++ b/blog/wealth-mindset.html
@@ -92,6 +92,15 @@
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to connect personal growth to action you can repeat. One well-chosen action, repeated often enough, becomes part of your identity.</p>
     </section>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">
       <h2 style="margin-top:0">Related reading on Motivational-Quote.org</h2>

--- a/blog/why-comparison-is-the-thief-of-joy.html
+++ b/blog/why-comparison-is-the-thief-of-joy.html
@@ -109,6 +109,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/why-consistency-trumps-intensity.html
+++ b/blog/why-consistency-trumps-intensity.html
@@ -109,6 +109,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/why-discipline-beats-motivation.html
+++ b/blog/why-discipline-beats-motivation.html
@@ -115,6 +115,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/why-small-wins-matter.html
+++ b/blog/why-small-wins-matter.html
@@ -99,6 +99,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/willpower-science.html
+++ b/blog/willpower-science.html
@@ -127,6 +127,15 @@
                 <li><strong>Reduced decision load:</strong> While the strong glucose-depletion model has not survived, the softer claim — that decision fatigue is real and that reducing unnecessary decisions conserves self-regulatory capacity for important ones — has significant support. Simplifying regular decisions through scheduling, defaults, and rules reduces the cognitive and motivational load that competing decisions would otherwise impose.</li>
                 <li><strong>Values connection:</strong> As discussed: the clearer the connection between the self-control demand and something you genuinely value, the less it depletes and the more naturally it sustains. Regular practices that clarify and reconnect to values — journaling, meaningful conversation, contemplative practice — support the motivational foundation of self-control as much as anything else.</li>
             </ul>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/writing-habit.html
+++ b/blog/writing-habit.html
@@ -129,6 +129,15 @@
                     <li><strong>Day 7:</strong> Review the week's writing. What surprised you? What questions emerged? What ideas recur across sessions? The review practice is where the compounding begins — you are building on a week's worth of externalized thinking rather than starting fresh.</li>
                 </ul>
             </div>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
         
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/zen-focus.html
+++ b/blog/zen-focus.html
@@ -111,6 +111,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>For a Western-friendly deep dive into Zen principles applied to work and creativity, <a href="https://www.amazon.com/dp/0385472579?tag=mq061-20" rel="noopener sponsored"><em>Zen Mind, Beginner's Mind</em> by Shunryu Suzuki</a> remains the essential starting point. It's deceptively short and endlessly re-readable. Also available as an audiobook on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a> for commutes and walks.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/zen-growth.html
+++ b/blog/zen-growth.html
@@ -110,6 +110,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>For a beautiful, accessible introduction to Zen principles applied to creative mastery, <a href="https://www.amazon.com/dp/0385472579?tag=mq061-20" rel="noopener sponsored"><em>Zen Mind, Beginner's Mind</em> by Shunryu Suzuki</a> remains transformative. For the Western psychological parallel, Carol Dweck's <a href="https://www.amazon.com/dp/0345472322?tag=mq061-20" rel="noopener sponsored"><em>Mindset: The New Psychology of Success</em></a> covers growth orientation with rigorous research. Both are on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/zen-habits.html
+++ b/blog/zen-habits.html
@@ -110,6 +110,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>James Clear's <a href="https://www.amazon.com/dp/0735211299?tag=mq061-20" rel="noopener sponsored"><em>Atomic Habits</em></a> is the definitive modern synthesis of habit research — practical, research-backed, and full of concrete implementation strategies. BJ Fogg's <a href="https://www.amazon.com/dp/0358003326?tag=mq061-20" rel="noopener sponsored"><em>Tiny Habits</em></a> is the academic source behind many of the ideas above and complements it beautifully. Both are available on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/zen-learning.html
+++ b/blog/zen-learning.html
@@ -113,6 +113,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>For a deeper exploration of beginner's mind and Zen practice, <a href="https://www.amazon.com/dp/1590308492?tag=mq061-20" rel="noopener sponsored">Zen Mind, Beginner's Mind by Shunryu Suzuki</a> remains the definitive introduction. Also available as an audiobook on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a> — ideal for absorbing its gentle wisdom during a morning walk.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/zen-mastery.html
+++ b/blog/zen-mastery.html
@@ -107,6 +107,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>Eugen Herrigel's <a href="https://www.amazon.com/dp/0375705155?tag=mq061-20" rel="noopener sponsored"><em>Zen in the Art of Archery</em></a> remains one of the most profound and accessible introductions to Zen mastery principles in practice — a short but transformative read. Also available on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/zen-progress.html
+++ b/blog/zen-progress.html
@@ -111,6 +111,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>For a masterclass on Zen-influenced performance, <a href="https://www.amazon.com/dp/0743277465?tag=mq061-20" rel="noopener sponsored">The Art of Learning by Josh Waitzkin</a> is essential reading. Also available on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a> for a thought-provoking listen during your commute or morning walk.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/zen-success.html
+++ b/blog/zen-success.html
@@ -112,6 +112,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>For the foundational text, <a href="https://www.amazon.com/dp/1590308492?tag=mq061-20" rel="noopener sponsored"><em>Zen Mind, Beginner's Mind</em> by Shunryu Suzuki</a> is unmatched — compact, profound, and deeply practical. Also available as an audiobook on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/blog/zen-thinking.html
+++ b/blog/zen-thinking.html
@@ -112,6 +112,15 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>Further Reading</h2>
     <p>For a rigorous exploration of Zen and the mind, <a href="https://www.amazon.com/dp/0060723750?tag=mq061-20" rel="noopener sponsored">Zen and the Art of Motorcycle Maintenance by Robert Pirsig</a> remains one of the most penetrating Western investigations of Zen thinking and quality of attention. Also available as an audiobook on <a href="https://www.amazon.com/hz/audible/mlp/mfpdpdp?tag=mq061-20" rel="noopener sponsored">Audible</a>.</p>
+    <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
+      <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
 
 
     <section class="related-reading" style="background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:28px 0;">

--- a/resources.html
+++ b/resources.html
@@ -111,6 +111,19 @@
   </div>
 
   <main>
+    <section class="resources-section">
+      <h2>Start with your current goal</h2>
+      <div class="resource-card">
+        <span class="badge">Quick guide</span>
+        <h3>Choose the right resource path</h3>
+        <p>If you are trying to build a habit, start with <strong>Atomic Habits</strong>. If you are struggling with focus, start with <strong>Deep Work</strong>. If you want weekly accountability, start with the free newsletter. Pick one path and use it for two weeks before adding more.</p>
+        <div class="next-step-actions">
+          <a href="https://www.amazon.com/dp/0735211299?tag=mq061-20" rel="noopener sponsored" class="primary">Build habits</a>
+          <a href="https://www.amazon.com/dp/1455586692?tag=mq061-20" rel="noopener sponsored" class="secondary">Improve focus</a>
+          <a href="subscribe.html" class="secondary">Get weekly prompts</a>
+        </div>
+      </div>
+    </section>
 
     <div class="resources-section">
       <h2>📚 Books for Personal Growth</h2>

--- a/style.css
+++ b/style.css
@@ -186,6 +186,51 @@ header {
     text-transform: uppercase;
 }
 
+.next-step-strip {
+    max-width: 800px;
+    margin: 2rem auto;
+    padding: 1.25rem;
+    border: 1px solid #dbeafe;
+    border-radius: 10px;
+    background: #eff6ff;
+}
+
+.next-step-strip h2,
+.next-step-strip h3 {
+    margin-top: 0;
+    color: #1e3a8a;
+}
+
+.next-step-strip p {
+    color: #374151;
+    margin-bottom: 1rem;
+}
+
+.next-step-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.next-step-actions a {
+    display: inline-block;
+    border-radius: 8px;
+    padding: 0.6rem 1rem;
+    text-decoration: none;
+    font-weight: 700;
+}
+
+.next-step-actions .primary {
+    background: #4f46e5;
+    color: #fff;
+}
+
+.next-step-actions .secondary {
+    border: 1px solid #c7d2fe;
+    color: #3730a3;
+    background: #fff;
+}
+
 footer {
     background-color: #333;
     color: #fff;


### PR DESCRIPTION
## Summary\n- Add a clearer resources-page start-by-goal buyer path\n- Add article-level next-step blocks to 231 blog pages\n- Route readers toward resources and newsletter signup without aggressive ad placement\n\n## Verification\n- Confirmed 231 blog pages include the next-step strip\n\nCloses #80