### PR TITLE
Sprint 4: add resource conversion paths

### DIFF
--- a/blog/atomic-habits-key-lessons.html
+++ b/blog/atomic-habits-key-lessons.html
@@ -105,6 +105,16 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
     <h2>Further Reading</h2>
     <p>If you haven't read <em>Atomic Habits</em> itself, it's worth the full read — the summary never fully captures the depth. Our <a href="/resources.html">Resources page</a> has additional book recommendations on behavior change and habit science. For support maintaining habits through stress and difficult periods, <a href="https://headspace.com" rel="noopener sponsored">Headspace</a> offers stress-specific mindfulness content that helps protect the mental space habits need to survive.</p>
 
+    <section class="next-step-strip" style="background:#f5f3ff;border:1px solid #ddd6fe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+      <h2 style="margin-top:0;color:#4c1d95;">Turn the lessons into a two-week habit reset</h2>
+      <p style="color:#374151;">Start with the book, choose one tiny habit, and use a weekly prompt to keep the system visible while the results are still compounding.</p>
+      <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="https://www.amazon.com/dp/0735211299?tag=mq061-20" rel="noopener sponsored" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get Atomic Habits</a>
+        <a href="../resources.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse habit resources</a>
+        <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+      </div>
+    </section>
+
     <div class="ad-slot">
       <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-6175161566333696" data-ad-slot="auto" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>

--- a/resources.html
+++ b/resources.html
@@ -85,6 +85,22 @@
       color: #9ca3af;
       text-align: center;
     }
+    .path-grid {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+    }
+    .path-card {
+      background: #fff;
+      border: 1px solid #e0e7ff;
+      border-radius: 12px;
+      padding: 1.1rem;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+    }
+    .path-card h3 { margin: 0 0 0.4rem; color: #312e81; font-size: 1rem; }
+    .path-card p { margin: 0 0 0.85rem; color: #4b5563; font-size: 0.92rem; line-height: 1.5; }
+    .path-card a { color: #4f46e5; font-weight: 700; text-decoration: none; }
+    .path-card a:hover { text-decoration: underline; }
     footer { text-align: center; padding: 1.5rem 1rem; color: #9ca3af; font-size: 0.85rem; border-top: 1px solid #e5e7eb; margin-top: 2rem; }
     footer a { color: #6b7280; text-decoration: none; }
     footer a:hover { text-decoration: underline; }
@@ -121,6 +137,27 @@
           <a href="https://www.amazon.com/dp/0735211299?tag=mq061-20" rel="noopener sponsored" class="primary">Build habits</a>
           <a href="https://www.amazon.com/dp/1455586692?tag=mq061-20" rel="noopener sponsored" class="secondary">Improve focus</a>
           <a href="subscribe.html" class="secondary">Get weekly prompts</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="resources-section">
+      <h2>Choose by outcome</h2>
+      <div class="path-grid">
+        <div class="path-card">
+          <h3>Build discipline</h3>
+          <p>Use habit design, small wins, and weekly reflection to make consistency easier.</p>
+          <a href="blog/atomic-habits-key-lessons.html">Read the habit guide →</a>
+        </div>
+        <div class="path-card">
+          <h3>Improve focus</h3>
+          <p>Start with deep work principles, remove shallow distractions, and protect attention.</p>
+          <a href="blog/deep-work-strategies.html">Read focus strategies →</a>
+        </div>
+        <div class="path-card">
+          <h3>Stay accountable</h3>
+          <p>Get a simple weekly prompt that turns motivation into a repeatable practice.</p>
+          <a href="subscribe.html">Join the newsletter →</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Add outcome-based routing to the resources page
- Add a dedicated Atomic Habits conversion block
- Route habit readers to Amazon, resources, and weekly prompts

## Verification
- Static internal-link validation run; existing validator reports pre-existing absolute-path/mailto references only

Closes #83