### PR TITLE
Add blog category filters

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -27,6 +27,11 @@
         .post-meta { color: var(--text-muted); font-size: 0.8rem; margin-bottom: 8px; }
         .post-title { font-size: 1.1rem; margin-bottom: 8px; color: var(--primary); line-height: 1.4; }
         .post-excerpt { color: var(--text-muted); font-size: 0.85rem; }
+
+        .category-filters { display: flex; flex-wrap: wrap; gap: 10px; margin: 0 0 30px; }
+        .category-filter { border: 1px solid var(--border); background: var(--card-bg); color: var(--text); border-radius: 999px; padding: 8px 14px; cursor: pointer; font: inherit; font-size: 0.9rem; transition: background 0.2s, border-color 0.2s, color 0.2s; }
+        .category-filter:hover, .category-filter.active { background: #4f46e5; border-color: #4f46e5; color: white; }
+        .post-card[hidden] { display: none; }
         footer { text-align: center; padding: 40px; color: var(--text-muted); border-top: 1px solid var(--border); margin-top: 60px; }
     </style>
     <link rel="manifest" href="manifest.json">
@@ -44,62 +49,75 @@
                 <a href="../subscribe.html">Subscribe</a>
             </nav>
         </header>
-        
+
         <h1>Motivation Blog</h1>
         <p class="subtitle">In-depth articles on personal growth, success, and motivation</p>
         <span class="post-count">231 Articles</span>
-        
+
+        <div class="category-filters" aria-label="Filter blog posts by category">
+            <button class="category-filter active" type="button" data-filter="All">All</button>
+            <button class="category-filter" type="button" data-filter="Mindfulness">Mindfulness</button>
+            <button class="category-filter" type="button" data-filter="Habits">Habits</button>
+            <button class="category-filter" type="button" data-filter="Productivity">Productivity</button>
+            <button class="category-filter" type="button" data-filter="Goal Setting">Goal Setting</button>
+            <button class="category-filter" type="button" data-filter="Motivation">Motivation</button>
+            <button class="category-filter" type="button" data-filter="Anxiety &amp; Stress">Anxiety &amp; Stress</button>
+            <button class="category-filter" type="button" data-filter="Morning Routines">Morning Routines</button>
+            <button class="category-filter" type="button" data-filter="Confidence">Confidence</button>
+            <button class="category-filter" type="button" data-filter="Gratitude">Gratitude</button>
+        </div>
+
         <div class="post-list">
-            <div class="post-card">
+            <div class="post-card" data-category="Productivity">
                 <a href="deep-work-strategies.html">
                     <p class="post-meta">June 27</p>
                     <h2 class="post-title">Deep Work Strategies: How to Protect Your Most Valuable Cognitive Hours</h2>
                     <p class="post-excerpt">The ability to focus without distraction on cognitively demanding tasks is becoming rarer and more economically valuable simultaneously. Here are the science and strategies for cultivating it.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Productivity">
                 <a href="flow-state-triggers.html">
                     <p class="post-meta">June 27</p>
                     <h2 class="post-title">Flow State Triggers: How to Enter Peak Performance on Demand</h2>
                     <p class="post-excerpt">Flow states are not random. Research identifies specific conditions that reliably induce complete absorption and peak performance. Here is the complete framework for making flow a regular part of your work.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Goal Setting">
                 <a href="fear-of-success.html">
                     <p class="post-meta">June 22</p>
                     <h2 class="post-title">Fear of Success: Why We Self-Sabotage at the Threshold</h2>
                     <p class="post-excerpt">Getting close to your goal and then inexplicably stalling is not laziness &mdash; it is fear of success. Understanding the mechanisms behind self-sabotage is the key to moving through it.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Productivity">
                 <a href="cognitive-load-management.html">
                     <p class="post-meta">June 22</p>
                     <h2 class="post-title">Cognitive Load Management: How to Think Clearly in a Demanding World</h2>
                     <p class="post-excerpt">Your working memory holds roughly four chunks at once. Managing what competes for that capacity &mdash; open loops, environment, task sequencing &mdash; is one of the highest-leverage skills available.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Goal Setting">
                 <a href="intentional-living.html">
                     <p class="post-meta">June 20</p>
                     <h2 class="post-title">Intentional Living: How to Design a Life You Actually Chose</h2>
                     <p class="post-excerpt">Most people&apos;s lives were not designed &mdash; they accumulated. Intentional living is the deliberate alternative: building a life organized around what you actually value rather than what happened to happen.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Mindfulness">
                 <a href="self-awareness-practice.html">
                     <p class="post-meta">June 20</p>
                     <h2 class="post-title">Self-Awareness Practice: The Skill That Amplifies Every Other Skill</h2>
                     <p class="post-excerpt">95% of people believe they are self-aware; only 10&ndash;15% are by research standards. Here is what genuine self-awareness involves and how to systematically build both dimensions of it.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="cognitive-flexibility.html">
                     <p class="post-meta">June 18</p>
                     <h2 class="post-title">Cognitive Flexibility: The Mental Skill That Separates Adaptable Thinkers from Rigid Ones</h2>
                     <p class="post-excerpt">The ability to shift between mental frameworks, update views in response to new evidence, and hold multiple perspectives at once &mdash; it is trainable, and increasingly essential.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Confidence">
                 <a href="self-efficacy.html">
                     <p class="post-meta">June 18</p>
                     <h2 class="post-title">Self-Efficacy: The Science of Believing You Can &mdash; and Making It True</h2>
@@ -107,42 +125,42 @@
                 </a>
             </div>
 
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="narrative-identity.html">
                     <p class="post-meta">June 16</p>
                     <h2 class="post-title">Narrative Identity: How the Story You Tell Yourself Shapes Everything</h2>
                     <p class="post-excerpt">You are the story you construct from your experiences. Narrative identity theory reveals how the account you tell yourself determines your resilience, decisions, and capacity to grow.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="learned-optimism.html">
                     <p class="post-meta">June 16</p>
                     <h2 class="post-title">Learned Optimism: The Science of Building a Resilient Explanatory Style</h2>
                     <p class="post-excerpt">Optimism is not a personality type you either have or don&apos;t. It is an explanatory style that predicts resilience, health, and achievement — and it can be deliberately built.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Productivity">
                 <a href="decision-fatigue.html">
                     <p class="post-meta">June 15</p>
                     <h2 class="post-title">Decision Fatigue: Why Your Willpower Runs Out and How to Fix It</h2>
                     <p class="post-excerpt">Every decision depletes the same mental resource. When it runs low, your judgment degrades in predictable ways. Here is the science and how to design your day to stay sharp.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Mindfulness">
                 <a href="emotional-regulation.html">
                     <p class="post-meta">June 15</p>
                     <h2 class="post-title">Emotional Regulation: The Science of Managing Your Inner World</h2>
                     <p class="post-excerpt">Emotional regulation is not suppression &mdash; it is the ability to experience the full range of emotions without being controlled by them. Here is the science and a practical system for building it.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="spaced-repetition-learning.html">
                     <p class="post-meta">June 14</p>
                     <h2 class="post-title">Spaced Repetition: The Science of Making Knowledge Stick</h2>
                     <p class="post-excerpt">The forgetting curve is steep and predictable. Spaced repetition &mdash; reviewing material at expanding intervals just before you forget it &mdash; is the most evidence-backed learning technique available.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Habits">
                 <a href="temptation-bundling.html">
                     <p class="post-meta">June 19</p>
                     <h2 class="post-title">Temptation Bundling: The Science of Making Good Habits Feel Good</h2>
@@ -150,154 +168,154 @@
                 </a>
             </div>
 
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="morning-pages-for-clarity.html">
                     <p class="post-meta">June 13</p>
                     <h2 class="post-title">Morning Pages for Clarity: The Science Behind Writing Your Way to a Better Mind</h2>
                     <p class="post-excerpt">Three pages of longhand stream-of-consciousness writing every morning. The science of expressive writing explains why Julia Cameron&rsquo;s practice produces cognitive clarity, creative unblocking, and self-knowledge.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="deliberate-practice.html">
                     <p class="post-meta">June 13</p>
                     <h2 class="post-title">Deliberate Practice: The Science of Becoming Exceptional at Anything</h2>
                     <p class="post-excerpt">Expertise is not the product of talent or time &mdash; it is the product of a specific type of practice. Anders Ericsson&rsquo;s research reveals what separates elite performers from experienced amateurs.</p>
                 </a>
             </div>
-                        <div class="post-card">
+                        <div class="post-card" data-category="All">
                 <a href="the-role-of-boredom-in-creativity.html">
                     <p class="post-meta">June 11</p>
                     <h2 class="post-title">The Role of Boredom in Creativity: Why Idle Minds Generate Better Ideas</h2>
                     <p class="post-excerpt">Boredom activates the default mode network &mdash; the brain system responsible for insight and creative synthesis. Here&rsquo;s why eliminating idle time may be eliminating your best ideas.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="post-traumatic-growth-science.html">
                     <p class="post-meta">June 11</p>
                     <h2 class="post-title">Post-Traumatic Growth: The Science of How Adversity Can Transform You</h2>
                     <p class="post-excerpt">PTG is measurable positive psychological change that emerges from the struggle with serious adversity &mdash; not the absence of suffering, but transformation alongside it.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="creative-confidence.html">
                     <p class="post-meta">June 11</p>
                     <h2 class="post-title">Creative Confidence: How to Reclaim Your Creative Voice and Act on Ideas</h2>
                     <p class="post-excerpt">Creative confidence is a learned skill, not an innate talent. Here&rsquo;s the neuroscience of why anxiety kills creativity, and how graduated exposure rebuilds the willingness to act on ideas.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Habits">
                 <a href="habit-renewal.html">
                     <p class="post-meta">June 11</p>
                     <h2 class="post-title">Habit Renewal: How to Reset and Rebuild Habits That Stick</h2>
                     <p class="post-excerpt">All habits decay. Understanding whether yours failed due to context disruption, reward dilution, or identity drift tells you exactly how to rebuild them stronger than before.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="skill-stacking-career.html">
                     <p class="post-meta">June 11</p>
                     <h2 class="post-title">Skill Stacking: How to Build a Career Advantage by Combining Skills</h2>
                     <p class="post-excerpt">You don't need to be the best in the world at one skill. Combine three good-enough complementary skills and you create a combination fewer than 1% of people share.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Productivity">
                 <a href="productive-solitude.html">
                     <p class="post-meta">June 11</p>
                     <h2 class="post-title">Productive Solitude: Why Time Alone Is Your Most Underused Performance Tool</h2>
                     <p class="post-excerpt">The default mode network, the science of insight, and why filling every quiet moment with content may be quietly impairing your best thinking.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Habits">
                 <a href="essentialism-in-practice.html">
                     <p class="post-meta">June 6</p>
                     <h2 class="post-title">Essentialism in Practice: The Disciplined Pursuit of Less</h2>
                     <p class="post-excerpt">Less but better. Greg McKeown's framework for cutting the trivial many, the 90% rule, and reclaiming control of your time and focus.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Productivity">
                 <a href="building-a-second-brain.html">
                     <p class="post-meta">June 6</p>
                     <h2 class="post-title">Building a Second Brain: A System for Organizing Your Digital Life</h2>
                     <p class="post-excerpt">Your mind is for having ideas, not holding them. Tiago Forte's CODE and PARA methods for capturing what you learn and actually using it.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Habits">
                 <a href="champion-habits.html">
                     <p class="post-meta">June 6</p>
                     <h2 class="post-title">Champion Habits: The Science of Building Habits That Stick</h2>
                     <p class="post-excerpt">Lasting habits come from design, not willpower&mdash;the habit loop, the real ~66-day timeline, and the systems that make good behaviors automatic.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="expert-learning.html">
                     <p class="post-meta">June 6</p>
                     <h2 class="post-title">Expert Learning: How Top Performers Actually Master Skills</h2>
                     <p class="post-excerpt">Expertise is built, not born. The science of deliberate practice, why the 10,000-hour rule is misunderstood, and how to structure practice that compounds.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="active-recall-learning.html">
                     <p class="post-meta">June 4</p>
                     <h2 class="post-title">Active Recall: The Most Effective Way to Learn Anything</h2>
                     <p class="post-excerpt">Retrieving information from memory beats rereading every time&mdash;the research-backed technique for learning faster and remembering longer.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Productivity">
                 <a href="attention-residue.html">
                     <p class="post-meta">June 4</p>
                     <h2 class="post-title">Attention Residue: Why Task-Switching Quietly Wrecks Your Focus</h2>
                     <p class="post-excerpt">Every task switch leaves a cognitive wake that drags down the next task. The science of attention residue&mdash;and how to stop it.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Habits">
                 <a href="adaptive-habits.html">
                     <p class="post-meta">June 4</p>
                     <h2 class="post-title">Adaptive Habits: How to Build Routines That Bend Instead of Break</h2>
                     <p class="post-excerpt">Rigid routines shatter when life gets messy. Build habits that flex with travel, stress, and change so your streak survives.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Habits">
                 <a href="victory-habits.html">
                     <p class="post-meta">June 4</p>
                     <h2 class="post-title">Victory Habits: The Daily Systems That Turn Ordinary Effort Into Lasting Success</h2>
                     <p class="post-excerpt">The small, repeatable habits that compound into outsized results&mdash;and how to design, stack, and sustain them.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Goal Setting">
                 <a href="values-clarification.html">
                     <p class="post-meta">June 3</p>
                     <h2 class="post-title">Values Clarification: How to Find What Genuinely Matters and Build Your Life Around It</h2>
                     <p class="post-excerpt">The evidence-based process of identifying your real values—not inherited ones—and aligning your life with what actually matters.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="learned-optimism.html">
                     <p class="post-meta">June 3</p>
                     <h2 class="post-title">Learned Optimism: The Science of Thinking Your Way to Resilience and Performance</h2>
                     <p class="post-excerpt">Martin Seligman's research-backed cognitive skills that protect against depression, predict performance, and build genuine resilience.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="narrative-identity.html">
                     <p class="post-meta">June 1</p>
                     <h2 class="post-title">Narrative Identity: The Story You Tell About Yourself Determines Your Future</h2>
                     <p class="post-excerpt">How the story you construct about your life shapes your behavior, resilience, and potential—and how to rewrite it.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Productivity">
                 <a href="ultradian-rhythm-productivity.html">
                     <p class="post-meta">June 1</p>
                     <h2 class="post-title">Ultradian Rhythm Productivity: Work With Your Brain's 90-Minute Cycles</h2>
                     <p class="post-excerpt">Your brain pulses in natural 90-minute performance cycles. Learn to align your work with these rhythms for more output and less burnout.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Productivity">
                 <a href="rest-as-strategy.html">
                     <p class="post-meta">June 2</p>
                     <h2 class="post-title">Rest as Strategy: Why High Performers Treat Recovery as a Performance Tool</h2>
                     <p class="post-excerpt">The science of deliberate rest — why recovery is the mechanism of growth, not the absence of it.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Motivation">
                 <a href="the-zeigarnik-effect.html">
                     <p class="post-meta">June 2</p>
                     <h2 class="post-title">The Zeigarnik Effect: Why Your Brain Can't Let Go of Unfinished Tasks</h2>
@@ -305,770 +323,770 @@
                 </a>
             </div>
 
-            <div class="post-card">
+            <div class="post-card" data-category="Habits">
                 <a href="the-science-of-habit-formation.html">
                     <p class="post-meta">March 14</p>
                     <h2 class="post-title">The Science of Habit Formation</h2>
                     <p class="post-excerpt">Understanding the neuroscience behind habits.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Morning Routines">
                 <a href="morning-routines-successful-people.html">
                     <p class="post-meta">March 15</p>
                     <h2 class="post-title">Morning Routines of Highly Successful People</h2>
                     <p class="post-excerpt">What science says about morning habits.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="overcoming-procrastination.html">
                     <p class="post-meta">March 16</p>
                     <h2 class="post-title">Overcoming Procrastination</h2>
                     <p class="post-excerpt">The psychology behind delay and how to beat it.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Motivation">
                 <a href="growth-vs-fixed-mindset.html">
                     <p class="post-meta">March 17</p>
                     <h2 class="post-title">Growth Mindset vs Fixed Mindset</h2>
                     <p class="post-excerpt">Carol Dweck's research and practical applications.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="power-of-deliberate-practice.html">
                     <p class="post-meta">March 18</p>
                     <h2 class="post-title">The Power of Deliberate Practice</h2>
                     <p class="post-excerpt">How experts really master their skills.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Motivation">
                 <a href="understanding-motivation.html">
                     <p class="post-meta">March 19</p>
                     <h2 class="post-title">Understanding Motivation</h2>
                     <p class="post-excerpt">What drives human behavior.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="resilience-building.html">
                     <p class="post-meta">March 20</p>
                     <h2 class="post-title">Building Resilience</h2>
                     <p class="post-excerpt">Bouncing back from life's challenges.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Goal Setting">
                 <a href="goal-setting-science.html">
                     <p class="post-meta">March 21</p>
                     <h2 class="post-title">The Science of Goal Setting</h2>
                     <p class="post-excerpt">Why most goals fail and how to succeed.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="sleep-performance.html">
                     <p class="post-meta">March 22</p>
                     <h2 class="post-title">Sleep and Peak Performance</h2>
                     <p class="post-excerpt">The critical connection often ignored.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Habits">
                 <a href="self-discipline-mastery.html">
                     <p class="post-meta">March 23</p>
                     <h2 class="post-title">Self-Discipline Mastery</h2>
                     <p class="post-excerpt">The art of doing what needs to be done.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="fear-of-failure.html">
                     <p class="post-meta">March 24</p>
                     <h2 class="post-title">Conquering the Fear of Failure</h2>
                     <p class="post-excerpt">Reframing setbacks as opportunities.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Habits">
                 <a href="power-of-consistency.html">
                     <p class="post-meta">March 25</p>
                     <h2 class="post-title">The Power of Consistency</h2>
                     <p class="post-excerpt">Why small actions compound over time.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Mindfulness">
                 <a href="emotional-intelligence.html">
                     <p class="post-meta">March 26</p>
                     <h2 class="post-title">Emotional Intelligence</h2>
                     <p class="post-excerpt">The secret weapon for success.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Productivity">
                 <a href="time-management-myths.html">
                     <p class="post-meta">March 27</p>
                     <h2 class="post-title">Time Management Myths Debunked</h2>
                     <p class="post-excerpt">What actually works.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Confidence">
                 <a href="confidence-building.html">
                     <p class="post-meta">March 28</p>
                     <h2 class="post-title">Building Unshakeable Confidence</h2>
                     <p class="post-excerpt">Beyond fake it till you make it.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Productivity">
                 <a href="focus-deep-work.html">
                     <p class="post-meta">March 29</p>
                     <h2 class="post-title">Deep Work</h2>
                     <p class="post-excerpt">The productivity superpower.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Gratitude">
                 <a href="gratitude-practice.html">
                     <p class="post-meta">March 30</p>
                     <h2 class="post-title">The Science of Gratitude</h2>
                     <p class="post-excerpt">How thankfulness transforms your brain.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="negative-self-talk.html">
                     <p class="post-meta">March 31</p>
                     <h2 class="post-title">Taming Negative Self-Talk</h2>
                     <p class="post-excerpt">Changing your inner dialogue.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Motivation">
                 <a href="delayed-gratification.html">
                     <p class="post-meta">April 1</p>
                     <h2 class="post-title">The Art of Delayed Gratification</h2>
                     <p class="post-excerpt">Mastering impulse for long-term success.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Confidence">
                 <a href="comfort-zone-expansion.html">
                     <p class="post-meta">April 2</p>
                     <h2 class="post-title">Comfort Zone Expansion</h2>
                     <p class="post-excerpt">Strategic risk-taking for growth.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Habits">
                 <a href="identity-based-habits.html">
                     <p class="post-meta">April 3</p>
                     <h2 class="post-title">Identity-Based Habits</h2>
                     <p class="post-excerpt">The most effective behavior change.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="stress-management.html">
                     <p class="post-meta">April 4</p>
                     <h2 class="post-title">Effective Stress Management</h2>
                     <p class="post-excerpt">Practical techniques for modern life.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Goal Setting">
                 <a href="purpose-discovery.html">
                     <p class="post-meta">April 5</p>
                     <h2 class="post-title">Discovering Your Purpose</h2>
                     <p class="post-excerpt">Beyond the finding yourself myth.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="perfectionism-recovery.html">
                     <p class="post-meta">April 6</p>
                     <h2 class="post-title">Overcoming Perfectionism</h2>
                     <p class="post-excerpt">Embracing good enough.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="positive-environment.html">
                     <p class="post-meta">April 7</p>
                     <h2 class="post-title">Designing Your Environment</h2>
                     <p class="post-excerpt">The hidden driver of behavior.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Productivity">
                 <a href="energy-management.html">
                     <p class="post-meta">April 8</p>
                     <h2 class="post-title">Energy Management</h2>
                     <p class="post-excerpt">The real metric for productivity.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Motivation">
                 <a href="social-support.html">
                     <p class="post-meta">April 9</p>
                     <h2 class="post-title">The Power of Social Support</h2>
                     <p class="post-excerpt">Relationships drive success.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="learning-speed.html">
                     <p class="post-meta">April 10</p>
                     <h2 class="post-title">Accelerated Learning</h2>
                     <p class="post-excerpt">Master new skills faster.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="decision-making.html">
                     <p class="post-meta">April 11</p>
                     <h2 class="post-title">Better Decision Making</h2>
                     <p class="post-excerpt">Frameworks for choices that count.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="failure-embracing.html">
                     <p class="post-meta">April 12</p>
                     <h2 class="post-title">Embracing Failure</h2>
                     <p class="post-excerpt">The essential mindset for growth.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Motivation">
                 <a href="motivation-maintenance.html">
                     <p class="post-meta">April 13</p>
                     <h2 class="post-title">Sustaining Motivation</h2>
                     <p class="post-excerpt">Beyond the initial spark.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="imposter-syndrome.html">
                     <p class="post-meta">April 14</p>
                     <h2 class="post-title">Conquering Imposter Syndrome</h2>
                     <p class="post-excerpt">Owning your achievements.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="criticism-handling.html">
                     <p class="post-meta">April 15</p>
                     <h2 class="post-title">Handling Criticism</h2>
                     <p class="post-excerpt">Separating signal from noise.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Motivation">
                 <a href="visualization-power.html">
                     <p class="post-meta">April 16</p>
                     <h2 class="post-title">The Power of Visualization</h2>
                     <p class="post-excerpt">Mental rehearsal for results.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Mindfulness">
                 <a href="self-awareness.html">
                     <p class="post-meta">April 17</p>
                     <h2 class="post-title">Developing Self-Awareness</h2>
                     <p class="post-excerpt">The foundation of growth.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="pressure-performance.html">
                     <p class="post-meta">April 18</p>
                     <h2 class="post-title">Performing Under Pressure</h2>
                     <p class="post-excerpt">Thriving in high-stress situations.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="saying-no.html">
                     <p class="post-meta">April 19</p>
                     <h2 class="post-title">The Art of Saying No</h2>
                     <p class="post-excerpt">Protecting your time.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Productivity">
                 <a href="chronotype-productivity.html">
                     <p class="post-meta">April 20</p>
                     <h2 class="post-title">Chronotype Optimization</h2>
                     <p class="post-excerpt">Working with your biology.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="competition-self.html">
                     <p class="post-meta">April 21</p>
                     <h2 class="post-title">Competing with Yourself</h2>
                     <p class="post-excerpt">The only race that matters.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="exercise-brain.html">
                     <p class="post-meta">April 22</p>
                     <h2 class="post-title">Exercise and the Brain</h2>
                     <p class="post-excerpt">Physical fuels mental.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Mindfulness">
                 <a href="meditation-habits.html">
                     <p class="post-meta">April 23</p>
                     <h2 class="post-title">Meditation for Habits</h2>
                     <p class="post-excerpt">Training discipline.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="journaling-power.html">
                     <p class="post-meta">April 24</p>
                     <h2 class="post-title">The Power of Journaling</h2>
                     <p class="post-excerpt">Writing your way to clarity.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Productivity">
                 <a href="minimalism-productivity.html">
                     <p class="post-meta">April 25</p>
                     <h2 class="post-title">Minimalism for Productivity</h2>
                     <p class="post-excerpt">Doing less to achieve more.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Gratitude">
                 <a href="celebrating-wins.html">
                     <p class="post-meta">April 26</p>
                     <h2 class="post-title">The Importance of Celebrating Wins</h2>
                     <p class="post-excerpt">Reinforcing progress.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Motivation">
                 <a href="rest-recovery.html">
                     <p class="post-meta">April 27</p>
                     <h2 class="post-title">Rest and Recovery</h2>
                     <p class="post-excerpt">The underrated component of success.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="authentic-networking.html">
                     <p class="post-meta">April 28</p>
                     <h2 class="post-title">Authentic Networking</h2>
                     <p class="post-excerpt">Building genuine relationships.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Motivation">
                 <a href="storytelling-success.html">
                     <p class="post-meta">April 29</p>
                     <h2 class="post-title">The Role of Storytelling</h2>
                     <p class="post-excerpt">Communicating with impact.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Goal Setting">
                 <a href="values-living.html">
                     <p class="post-meta">April 30</p>
                     <h2 class="post-title">Living Your Values</h2>
                     <p class="post-excerpt">The foundation of authentic success.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="feedback-loops.html">
                     <p class="post-meta">May 1</p>
                     <h2 class="post-title">Creating Feedback Loops</h2>
                     <p class="post-excerpt">Accelerating your learning.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Motivation">
                 <a href="wealth-mindset.html">
                     <p class="post-meta">May 2</p>
                     <h2 class="post-title">The Psychology of Money</h2>
                     <p class="post-excerpt">Developing a wealth mindset.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Confidence">
                 <a href="body-language.html">
                     <p class="post-meta">May 3</p>
                     <h2 class="post-title">Body Language and Success</h2>
                     <p class="post-excerpt">The non-verbal dimension.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="sunk-cost.html">
                     <p class="post-meta">May 4</p>
                     <h2 class="post-title">Overcoming Sunk Cost Fallacy</h2>
                     <p class="post-excerpt">When to cut your losses.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Habits">
                 <a href="habit-stacking.html">
                     <p class="post-meta">May 5</p>
                     <h2 class="post-title">Habit Stacking</h2>
                     <p class="post-excerpt">Linking behaviors to routines.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="dopamine-management.html">
                     <p class="post-meta">May 6</p>
                     <h2 class="post-title">Dopamine Management</h2>
                     <p class="post-excerpt">Avoiding the trap of easy rewards.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Mindfulness">
                 <a href="negative-visualization.html">
                     <p class="post-meta">May 7</p>
                     <h2 class="post-title">Negative Visualization</h2>
                     <p class="post-excerpt">The Stoic practice.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Habits">
                 <a href="anchor-habits.html">
                     <p class="post-meta">May 8</p>
                     <h2 class="post-title">Anchor Habits</h2>
                     <p class="post-excerpt">Using triggers to kickstart your day.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Habits">
                 <a href="micro-habits.html">
                     <p class="post-meta">May 9</p>
                     <h2 class="post-title">Micro Habits</h2>
                     <p class="post-excerpt">Starting incredibly small.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="choice-architecture.html">
                     <p class="post-meta">May 10</p>
                     <h2 class="post-title">Choice Architecture</h2>
                     <p class="post-excerpt">Designing your life.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="cognitive-reframing.html">
                     <p class="post-meta">May 11</p>
                     <h2 class="post-title">Cognitive Reframing</h2>
                     <p class="post-excerpt">Changing how you see situations.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Habits">
                 <a href="implementation-intentions.html">
                     <p class="post-meta">May 12</p>
                     <h2 class="post-title">Implementation Intentions</h2>
                     <p class="post-excerpt">The if-then strategy.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Motivation">
                 <a href="mental-contrasting.html">
                     <p class="post-meta">May 13</p>
                     <h2 class="post-title">Mental Contrasting</h2>
                     <p class="post-excerpt">Balancing optimism with reality.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="defaults-power.html">
                     <p class="post-meta">May 14</p>
                     <h2 class="post-title">The Power of Defaults</h2>
                     <p class="post-excerpt">How preset choices shape your life.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Motivation">
                 <a href="social-proof.html">
                     <p class="post-meta">May 15</p>
                     <h2 class="post-title">Social Proof and Success</h2>
                     <p class="post-excerpt">Leveraging peer influence.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="commitment-devices.html">
                     <p class="post-meta">May 16</p>
                     <h2 class="post-title">Commitment Devices</h2>
                     <p class="post-excerpt">Making good choices easier.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Gratitude">
                 <a href="progress-principle.html">
                     <p class="post-meta">May 17</p>
                     <h2 class="post-title">The Progress Principle</h2>
                     <p class="post-excerpt">How small wins create momentum.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="scarcity-abundance.html">
                     <p class="post-meta">May 18</p>
                     <h2 class="post-title">Scarcity vs Abundance</h2>
                     <p class="post-excerpt">Shifting your mental model.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Productivity">
                 <a href="flow-states.html">
                     <p class="post-meta">May 19</p>
                     <h2 class="post-title">Flow States</h2>
                     <p class="post-excerpt">The psychology of optimal experience.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="attribution-errors.html">
                     <p class="post-meta">May 20</p>
                     <h2 class="post-title">Attribution Errors</h2>
                     <p class="post-excerpt">Why we misjudge.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Productivity">
                 <a href="parkinsons-law.html">
                     <p class="post-meta">May 21</p>
                     <h2 class="post-title">Parkinson's Law</h2>
                     <p class="post-excerpt">Time expands to fill its container.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="antifragility.html">
                     <p class="post-meta">May 22</p>
                     <h2 class="post-title">Antifragility</h2>
                     <p class="post-excerpt">Thriving through stress.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="pareto-principle.html">
                     <p class="post-meta">May 23</p>
                     <h2 class="post-title">The Pareto Principle</h2>
                     <p class="post-excerpt">80/20 rule in personal development.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="occams-razor.html">
                     <p class="post-meta">May 24</p>
                     <h2 class="post-title">Occam's Razor</h2>
                     <p class="post-excerpt">Simpler solutions are often better.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="inversion-thinking.html">
                     <p class="post-meta">May 25</p>
                     <h2 class="post-title">Inversion</h2>
                     <p class="post-excerpt">Thinking backward.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="first-principles.html">
                     <p class="post-meta">May 26</p>
                     <h2 class="post-title">First Principles Thinking</h2>
                     <p class="post-excerpt">Breaking down complex problems.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Habits">
                 <a href="second-order-thinking.html">
                     <p class="post-meta">June 19</p>
                     <h2 class="post-title">Second-Order Thinking: The Mental Habit That Separates Good Decisions from Great Ones</h2>
                     <p class="post-excerpt">First-order thinking asks what will happen. Second-order thinking asks what will happen after that — and that gap is where most decisions are won or lost.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="circle-competence.html">
                     <p class="post-meta">May 28</p>
                     <h2 class="post-title">Circle of Competence</h2>
                     <p class="post-excerpt">Expanding what you know.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="regret-minimization.html">
                     <p class="post-meta">May 29</p>
                     <h2 class="post-title">Regret Minimization</h2>
                     <p class="post-excerpt">Making long-term decisions.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="reversible-decisions.html">
                     <p class="post-meta">May 30</p>
                     <h2 class="post-title">Reversible vs Irreversible</h2>
                     <p class="post-excerpt">When to act fast.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="convex-decisions.html">
                     <p class="post-meta">May 31</p>
                     <h2 class="post-title">Convex vs Concave</h2>
                     <p class="post-excerpt">Identifying asymmetric opportunities.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="optionality.html">
                     <p class="post-meta">June 1</p>
                     <h2 class="post-title">Optionality</h2>
                     <p class="post-excerpt">Keeping future choices open.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="margin-safety.html">
                     <p class="post-meta">June 2</p>
                     <h2 class="post-title">Margin of Safety</h2>
                     <p class="post-excerpt">Building resilience into plans.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="ergodicity.html">
                     <p class="post-meta">June 3</p>
                     <h2 class="post-title">Ergodicity</h2>
                     <p class="post-excerpt">Why averages don't apply.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="barbell-strategy.html">
                     <p class="post-meta">June 4</p>
                     <h2 class="post-title">The Barbel Strategy</h2>
                     <p class="post-excerpt">Extreme safety with risk.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="skin-in-game.html">
                     <p class="post-meta">June 5</p>
                     <h2 class="post-title">Skin in the Game</h2>
                     <p class="post-excerpt">Commitment creates results.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="via-negativa.html">
                     <p class="post-meta">June 6</p>
                     <h2 class="post-title">Via Negativa</h2>
                     <p class="post-excerpt">The power of subtraction.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="post-traumatic-growth.html">
                     <p class="post-meta">June 7</p>
                     <h2 class="post-title">Post-Traumatic Growth</h2>
                     <p class="post-excerpt">Growing through adversity.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Goal Setting">
                 <a href="meaning-making.html">
                     <p class="post-meta">June 8</p>
                     <h2 class="post-title">Meaning Making</h2>
                     <p class="post-excerpt">Creating purpose.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Motivation">
                 <a href="sustainable-success.html">
                     <p class="post-meta">June 9</p>
                     <h2 class="post-title">Beyond the Heroic Model</h2>
                     <p class="post-excerpt">Sustainable success without burnout.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Goal Setting">
                 <a href="autonomy-mastery-purpose.html">
                     <p class="post-meta">June 10</p>
                     <h2 class="post-title">Autonomy, Mastery, Purpose</h2>
                     <p class="post-excerpt">The three elements of motivation.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Mindfulness">
                 <a href="beginners-mind.html">
                     <p class="post-meta">June 11</p>
                     <h2 class="post-title">Beginner's Mind</h2>
                     <p class="post-excerpt">Staying curious.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Productivity">
                 <a href="systems-vs-goals.html">
                     <p class="post-meta">June 12</p>
                     <h2 class="post-title">Systems vs Goals</h2>
                     <p class="post-excerpt">Focus on processes over outcomes.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="inconvenience-yourself.html">
                     <p class="post-meta">June 13</p>
                     <h2 class="post-title">Self-Imposed Discomfort</h2>
                     <p class="post-excerpt">Building mental toughness.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Productivity">
                 <a href="monk-mode.html">
                     <p class="post-meta">June 14</p>
                     <h2 class="post-title">Monk Mode</h2>
                     <p class="post-excerpt">Intense focus periods.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Productivity">
                 <a href="environment-cleanup.html">
                     <p class="post-meta">June 15</p>
                     <h2 class="post-title">Digital Minimalism</h2>
                     <p class="post-excerpt">Cleaning your digital life.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Habits">
                 <a href="reading-habit.html">
                     <p class="post-meta">June 16</p>
                     <h2 class="post-title">The Reading Habit</h2>
                     <p class="post-excerpt">Continuous learning.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Habits">
                 <a href="writing-habit.html">
                     <p class="post-meta">June 19</p>
                     <h2 class="post-title">The Writing Habit: How Daily Writing Sharpens Thinking and Compounds Over Time</h2>
                     <p class="post-excerpt">Writing is not just the output of thinking — it is one of its most powerful inputs. Here is the cognitive science and a practical daily system.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="All">
                 <a href="asking-questions.html">
                     <p class="post-meta">June 18</p>
                     <h2 class="post-title">The Art of Asking Questions</h2>
                     <p class="post-excerpt">Curiosity as advantage.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="accepting-uncertainty.html">
                     <p class="post-meta">June 19</p>
                     <h2 class="post-title">Embracing Uncertainty</h2>
                     <p class="post-excerpt">Thriving in an unknown future.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Motivation">
                 <a href="identity-shift.html">
                     <p class="post-meta">June 19</p>
                     <h2 class="post-title">The Identity Shift: Why Changing Who You Are Changes What You Do</h2>
                     <p class="post-excerpt">Identity-based change is more durable than willpower. Change your self-concept first and the behaviors follow — here is the science and a 30-day protocol.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="envy-elimination.html">
                     <p class="post-meta">June 21</p>
                     <h2 class="post-title">Eliminating Envy</h2>
                     <p class="post-excerpt">Breaking the comparison trap.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Goal Setting">
                 <a href="legacy-thinking.html">
                     <p class="post-meta">June 22</p>
                     <h2 class="post-title">Legacy Thinking</h2>
                     <p class="post-excerpt">Thinking long-term.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Morning Routines">
                 <a href="how-to-build-a-morning-routine.html">
                     <p class="post-meta">May 10</p>
                     <h2 class="post-title">How to Build a Morning Routine That Actually Sticks</h2>
                     <p class="post-excerpt">Science-backed steps for a routine that survives real life.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Anxiety &amp; Stress">
                 <a href="overcoming-self-doubt.html">
                     <p class="post-meta">May 10</p>
                     <h2 class="post-title">Overcoming Self-Doubt: A Practical Guide</h2>
                     <p class="post-excerpt">Identify, challenge, and move past the inner voice that holds you back.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Habits">
                 <a href="growth-mindset-habits.html">
                     <p class="post-meta">May 10</p>
                     <h2 class="post-title">7 Daily Habits That Build a Growth Mindset</h2>
                     <p class="post-excerpt">Practical habits grounded in the science of learning and resilience.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Mindfulness">
                 <a href="mindfulness-for-beginners.html">
                     <p class="post-meta">May 10</p>
                     <h2 class="post-title">Mindfulness for Beginners: Start in 5 Minutes a Day</h2>
                     <p class="post-excerpt">No experience needed. Just an open mind and a few quiet minutes.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Habits">
                 <a href="atomic-habits-key-lessons.html">
                     <p class="post-meta">May 10</p>
                     <h2 class="post-title">Atomic Habits: The Key Lessons That Will Change Your Behavior</h2>
                     <p class="post-excerpt">The ideas from James Clear that will reshape how you approach change.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Goal Setting">
                 <a href="how-to-set-and-achieve-goals.html">
                     <p class="post-meta">May 10</p>
                     <h2 class="post-title">How to Set Goals You'll Actually Achieve</h2>
                     <p class="post-excerpt">A practical framework grounded in psychology, not wishful thinking.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Gratitude">
                 <a href="power-of-gratitude-journaling.html">
                     <p class="post-meta">May 10</p>
                     <h2 class="post-title">The Science Behind Gratitude Journaling (And How to Start)</h2>
                     <p class="post-excerpt">What the research actually shows and how to build a lasting practice.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Mindfulness">
                 <a href="self-compassion-science.html">
                     <p class="post-meta">June 17</p>
                     <h2 class="post-title">The Science of Self-Compassion: Why Treating Yourself Like a Friend Outperforms Self-Criticism</h2>
                     <p class="post-excerpt">Self-compassion predicts higher motivation, better resilience, and less fear of failure than self-criticism. Here is the research and how to build it.</p>
                 </a>
             </div>
-            <div class="post-card">
+            <div class="post-card" data-category="Goal Setting">
                 <a href="ikigai-finding-purpose.html">
                     <p class="post-meta">June 17</p>
                     <h2 class="post-title">Ikigai: The Japanese Framework for Finding Your Reason for Being</h2>
@@ -1076,9 +1094,28 @@
                 </a>
             </div>
         </div>
-        
+
         <footer><p>© 2026 <a href="../">motivational-quote.org</a> — Start each day inspired</p><p style="margin-top:6px;font-size:0.82rem;"><a href="../">Home</a> &nbsp;·&nbsp; <a href="./">Articles</a> &nbsp;·&nbsp; <a href="../about.html">About</a> &nbsp;·&nbsp; <a href="../contact.html">Contact</a> &nbsp;·&nbsp; <a href="../privacy.html">Privacy Policy</a></p></footer>
     </div>
+  <script>
+    const categoryButtons = document.querySelectorAll('.category-filter');
+    const postCards = document.querySelectorAll('.post-card[data-category]');
+
+    categoryButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+            const selectedCategory = button.dataset.filter;
+
+            categoryButtons.forEach((filterButton) => {
+                filterButton.classList.toggle('active', filterButton === button);
+            });
+
+            postCards.forEach((card) => {
+                const shouldShow = selectedCategory === 'All' || card.dataset.category === selectedCategory;
+                card.hidden = !shouldShow;
+            });
+        });
+    });
+  </script>
   <script src="../analytics.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds topic filter buttons to the blog index for All, Mindfulness, Habits, Productivity, Goal Setting, Motivation, Anxiety & Stress, Morning Routines, Confidence, and Gratitude.
- Tags each blog card with a `data-category` value inferred from the current href/title/excerpt and adds a no-framework click handler for filtering and active-button state.

Closes #25

## Verification
- Issue body snapshot at claim: `9f17840d194827ab`
- Original queue: `agios:escalate-codex`
- `grep -q "data-category" blog/index.html && grep -q "4f46e5" blog/index.html && echo OK`
- `python3 - <<'PY'
from html.parser import HTMLParser
HTMLParser().feed(open('blog/index.html', encoding='utf-8').read())
print('HTML OK')
PY`
- `git diff --check`
- Filter/category consistency check: `filters=10 cards=146 missing=[]`