### PR TITLE
Sprint 5: add habit and focus cluster links

### DIFF
--- a/blog/anchor-habits.html
+++ b/blog/anchor-habits.html
@@ -96,6 +96,7 @@
       <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
       <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>
       <div style="display:flex;flex-wrap:wrap;gap:10px;">
+        <a href="atomic-habits-key-lessons.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Read Atomic Habits lessons</a>
         <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse resources</a>
         <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
       </div>

--- a/blog/deep-work-strategies.html
+++ b/blog/deep-work-strategies.html
@@ -125,6 +125,15 @@
 
             <p>Several practices help contain shallow work effectively. Fixed-schedule productivity — Newport's practice of deciding in advance when the workday will end and working backward to determine what must be accomplished in the available time — forces prioritization decisions that ad hoc scheduling avoids. Email batching — checking email at two or three defined times per day rather than continuously — reduces the interruption frequency dramatically without meaningfully degrading response time for all but the most time-sensitive communications. And explicit time-blocking — scheduling every hour of the workday, including shallow work periods — eliminates the ambiguity that allows shallow work to expand indefinitely into available time.</p>
 
+            <section class="next-step-strip" style="background:#f5f3ff;border:1px solid #ddd6fe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
+                <h2 style="margin-top:0;color:#4c1d95;">Build a focus practice around this idea</h2>
+                <p style="color:#374151;">Pair the Deep Work framework with a practical resource path for focus, habits, and weekly accountability.</p>
+                <div style="display:flex;flex-wrap:wrap;gap:10px;">
+                    <a href="../resources.html" style="background:#4f46e5;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Browse focus resources</a>
+                    <a href="../subscribe.html" style="background:#fff;color:#3730a3;border:1px solid #c7d2fe;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:700;">Get weekly prompts</a>
+                </div>
+            </section>
+
             <div class="highlight">
                 <h3>Starting a Deep Work Practice: A Four-Week Protocol</h3>
                 <ul>


### PR DESCRIPTION
## Summary
- Add a focus-resource CTA to the Deep Work article
- Add an Atomic Habits link to the Anchor Habits next-step block
- Strengthen habit/focus resource routing

## Verification
- Static internal-link validation run; existing validator reports pre-existing absolute-path/mailto references only

Closes #88