### PR TITLE
[AGIOS] ux: Add Twitter and Pinterest social share buttons to 5 blog posts

### DIFF
--- a/blog/flow-states.html
+++ b/blog/flow-states.html
@@ -23,6 +23,12 @@
         li { margin-bottom: 8px; }
         blockquote { border-left: 4px solid var(--primary); padding-left: 20px; margin: 25px 0; font-style: italic; color: var(--text-muted); }
         .highlight { background: var(--card-bg); padding: 25px; border-radius: 12px; margin: 25px 0; border: 1px solid var(--border); }
+        .share-panel { background: var(--card-bg); padding: 24px; border-radius: 12px; margin: 28px 0; border: 1px solid var(--border); }
+        .share-panel h2 { margin: 0 0 10px; }
+        .share-panel p { margin-bottom: 14px; color: var(--text-muted); }
+        .share-actions { display: flex; flex-wrap: wrap; gap: 12px; }
+        .share-button { display: inline-flex; align-items: center; gap: 8px; padding: 11px 16px; border-radius: 999px; text-decoration: none; font-weight: 600; border: 1px solid var(--border); color: var(--text); background: rgba(99, 102, 241, 0.14); }
+        .share-button svg { width: 18px; height: 18px; fill: currentColor; }
         .tags { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 20px; }
         .tag { background: var(--card-bg); padding: 5px 15px; border-radius: 20px; font-size: 0.85rem; color: var(--text-muted); }
         .cta { background: linear-gradient(135deg, var(--primary), var(--secondary)); padding: 35px; border-radius: 16px; text-align: center; margin: 40px 0; }
@@ -91,6 +97,20 @@
       <p>Start by naming the pressure honestly: the deadline, the awkward message, the habit you keep postponing, or the emotion you would rather avoid. Then start the next clear task. Do not try to solve the entire pattern in one heroic push. Choose the next action that makes the better path easier to continue.</p>
       <p>For example, if the problem is avoidance, write the first two sentences instead of promising to finish the whole project. If the problem is overwhelm, remove one decision from your environment. If the problem is discouragement, document one piece of evidence that progress is still happening. Each version is small, but each one changes the direction of the day.</p>
       <p>The deeper benefit is that you begin to trust yourself. Confidence is not only a feeling; it is a memory of acting with care when the situation was imperfect. Use this page as a reminder to turn scattered effort into visible progress. One well-chosen action, repeated often enough, becomes part of your identity.</p>
+    </section>
+    <section class="share-panel">
+      <h2>Share this article</h2>
+      <p>Pass it along to someone who wants better focus and deeper work.</p>
+      <div class="share-actions">
+        <a class="share-button" href="https://twitter.com/intent/tweet?text=Flow%20States%3A%20The%20Psychology%20of%20Optimal%20Experience&url=https%3A%2F%2Fmotivational-quote.org%2Fblog%2Fflow-states.html" target="_blank" rel="noopener noreferrer" aria-label="Share Flow States on Twitter">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.901 1.153h3.68l-8.04 9.19L24 22.847h-7.406l-5.8-7.584-6.633 7.584H.48l8.6-9.83L0 1.153h7.594l5.243 6.932z"/></svg>
+          <span>Share on Twitter</span>
+        </a>
+        <a class="share-button" href="https://www.pinterest.com/pin/create/button/?url=https%3A%2F%2Fmotivational-quote.org%2Fblog%2Fflow-states.html&description=Flow%20States%3A%20The%20Psychology%20of%20Optimal%20Experience" target="_blank" rel="noopener noreferrer" aria-label="Share Flow States on Pinterest">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.477 2 2 6.02 2 10.98c0 3.916 2.813 7.247 6.718 8.42-.093-.714-.177-1.811.037-2.592.194-.707 1.248-4.502 1.248-4.502s-.318-.618-.318-1.532c0-1.435.86-2.506 1.93-2.506.91 0 1.349.652 1.349 1.434 0 .874-.58 2.18-.878 3.39-.249 1.013.53 1.84 1.573 1.84 1.888 0 3.338-1.898 3.338-4.637 0-2.424-1.814-4.12-4.402-4.12-3 0-4.762 2.152-4.762 4.376 0 .867.348 1.796.783 2.301a.31.31 0 0 1 .072.298c-.08.328-.26 1.04-.296 1.186-.047.19-.154.23-.355.139-1.326-.579-2.155-2.396-2.155-3.857 0-3.14 2.39-6.024 6.89-6.024 3.617 0 6.433 2.461 6.433 5.75 0 3.431-2.256 6.193-5.387 6.193-1.052 0-2.042-.524-2.38-1.145l-.647 2.43c-.234.876-.867 1.973-1.29 2.642.971.291 1.997.45 3.06.45 5.523 0 10-4.02 10-8.98C22 6.02 17.523 2 12 2"/></svg>
+          <span>Share on Pinterest</span>
+        </a>
+      </div>
     </section>
     <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
       <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>

--- a/blog/power-of-consistency.html
+++ b/blog/power-of-consistency.html
@@ -24,6 +24,12 @@
         li { margin-bottom: 8px; }
         blockquote { border-left: 4px solid var(--primary); padding-left: 20px; margin: 25px 0; font-style: italic; color: var(--text-muted); }
         .highlight { background: var(--card-bg); padding: 25px; border-radius: 12px; margin: 25px 0; border: 1px solid var(--border); }
+        .share-panel { background: var(--card-bg); padding: 24px; border-radius: 12px; margin: 28px 0; border: 1px solid var(--border); }
+        .share-panel h2 { margin: 0 0 10px; }
+        .share-panel p { margin-bottom: 14px; color: var(--text-muted); }
+        .share-actions { display: flex; flex-wrap: wrap; gap: 12px; }
+        .share-button { display: inline-flex; align-items: center; gap: 8px; padding: 11px 16px; border-radius: 999px; text-decoration: none; font-weight: 600; border: 1px solid var(--border); color: var(--text); background: rgba(99, 102, 241, 0.14); }
+        .share-button svg { width: 18px; height: 18px; fill: currentColor; }
         .tags { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 20px; }
         .tag { background: var(--card-bg); padding: 5px 15px; border-radius: 20px; font-size: 0.85rem; color: var(--text-muted); }
         .cta { background: linear-gradient(135deg, var(--primary), var(--secondary)); padding: 35px; border-radius: 16px; text-align: center; margin: 40px 0; }
@@ -81,6 +87,20 @@
 </ul>
 
 <p>The magic isn't in any single action—it's in the accumulation. Show up, do the work, repeat. That's the entire secret.</p>
+    <section class="share-panel">
+      <h2>Share this article</h2>
+      <p>Send it to someone who needs a reminder that small actions compound.</p>
+      <div class="share-actions">
+        <a class="share-button" href="https://twitter.com/intent/tweet?text=The%20Power%20of%20Consistency%3A%20Why%20Small%20Actions%20Compound%20Over%20Time&url=https%3A%2F%2Fmotivational-quote.org%2Fblog%2Fpower-of-consistency.html" target="_blank" rel="noopener noreferrer" aria-label="Share The Power of Consistency on Twitter">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.901 1.153h3.68l-8.04 9.19L24 22.847h-7.406l-5.8-7.584-6.633 7.584H.48l8.6-9.83L0 1.153h7.594l5.243 6.932z"/></svg>
+          <span>Share on Twitter</span>
+        </a>
+        <a class="share-button" href="https://www.pinterest.com/pin/create/button/?url=https%3A%2F%2Fmotivational-quote.org%2Fblog%2Fpower-of-consistency.html&description=The%20Power%20of%20Consistency%3A%20Why%20Small%20Actions%20Compound%20Over%20Time" target="_blank" rel="noopener noreferrer" aria-label="Share The Power of Consistency on Pinterest">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.477 2 2 6.02 2 10.98c0 3.916 2.813 7.247 6.718 8.42-.093-.714-.177-1.811.037-2.592.194-.707 1.248-4.502 1.248-4.502s-.318-.618-.318-1.532c0-1.435.86-2.506 1.93-2.506.91 0 1.349.652 1.349 1.434 0 .874-.58 2.18-.878 3.39-.249 1.013.53 1.84 1.573 1.84 1.888 0 3.338-1.898 3.338-4.637 0-2.424-1.814-4.12-4.402-4.12-3 0-4.762 2.152-4.762 4.376 0 .867.348 1.796.783 2.301a.31.31 0 0 1 .072.298c-.08.328-.26 1.04-.296 1.186-.047.19-.154.23-.355.139-1.326-.579-2.155-2.396-2.155-3.857 0-3.14 2.39-6.024 6.89-6.024 3.617 0 6.433 2.461 6.433 5.75 0 3.431-2.256 6.193-5.387 6.193-1.052 0-2.042-.524-2.38-1.145l-.647 2.43c-.234.876-.867 1.973-1.29 2.642.971.291 1.997.45 3.06.45 5.523 0 10-4.02 10-8.98C22 6.02 17.523 2 12 2"/></svg>
+          <span>Share on Pinterest</span>
+        </a>
+      </div>
+    </section>
     <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
       <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
       <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>

--- a/blog/resilience-building.html
+++ b/blog/resilience-building.html
@@ -24,6 +24,12 @@
         li { margin-bottom: 8px; }
         blockquote { border-left: 4px solid var(--primary); padding-left: 20px; margin: 25px 0; font-style: italic; color: var(--text-muted); }
         .highlight { background: var(--card-bg); padding: 25px; border-radius: 12px; margin: 25px 0; border: 1px solid var(--border); }
+        .share-panel { background: var(--card-bg); padding: 24px; border-radius: 12px; margin: 28px 0; border: 1px solid var(--border); }
+        .share-panel h2 { margin: 0 0 10px; }
+        .share-panel p { margin-bottom: 14px; color: var(--text-muted); }
+        .share-actions { display: flex; flex-wrap: wrap; gap: 12px; }
+        .share-button { display: inline-flex; align-items: center; gap: 8px; padding: 11px 16px; border-radius: 999px; text-decoration: none; font-weight: 600; border: 1px solid var(--border); color: var(--text); background: rgba(99, 102, 241, 0.14); }
+        .share-button svg { width: 18px; height: 18px; fill: currentColor; }
         .tags { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 20px; }
         .tag { background: var(--card-bg); padding: 5px 15px; border-radius: 20px; font-size: 0.85rem; color: var(--text-muted); }
         .cta { background: linear-gradient(135deg, var(--primary), var(--secondary)); padding: 35px; border-radius: 16px; text-align: center; margin: 40px 0; }
@@ -85,6 +91,20 @@
 </ul>
 
 <p>For a deeper dive into resilience and post-traumatic growth, consider <a href="https://www.amazon.com/dp/1524763422?tag=mq061-20" rel="noopener sponsored"><em>Option B</em></a> by Sheryl Sandberg.</p>
+    <section class="share-panel">
+      <h2>Share this article</h2>
+      <p>Pass it to someone who is rebuilding after a hard season.</p>
+      <div class="share-actions">
+        <a class="share-button" href="https://twitter.com/intent/tweet?text=Building%20Resilience%3A%20Bouncing%20Back%20Stronger%20from%20Life%27s%20Challenges&url=https%3A%2F%2Fmotivational-quote.org%2Fblog%2Fresilience-building.html" target="_blank" rel="noopener noreferrer" aria-label="Share Building Resilience on Twitter">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.901 1.153h3.68l-8.04 9.19L24 22.847h-7.406l-5.8-7.584-6.633 7.584H.48l8.6-9.83L0 1.153h7.594l5.243 6.932z"/></svg>
+          <span>Share on Twitter</span>
+        </a>
+        <a class="share-button" href="https://www.pinterest.com/pin/create/button/?url=https%3A%2F%2Fmotivational-quote.org%2Fblog%2Fresilience-building.html&description=Building%20Resilience%3A%20Bouncing%20Back%20Stronger%20from%20Life%27s%20Challenges" target="_blank" rel="noopener noreferrer" aria-label="Share Building Resilience on Pinterest">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.477 2 2 6.02 2 10.98c0 3.916 2.813 7.247 6.718 8.42-.093-.714-.177-1.811.037-2.592.194-.707 1.248-4.502 1.248-4.502s-.318-.618-.318-1.532c0-1.435.86-2.506 1.93-2.506.91 0 1.349.652 1.349 1.434 0 .874-.58 2.18-.878 3.39-.249 1.013.53 1.84 1.573 1.84 1.888 0 3.338-1.898 3.338-4.637 0-2.424-1.814-4.12-4.402-4.12-3 0-4.762 2.152-4.762 4.376 0 .867.348 1.796.783 2.301a.31.31 0 0 1 .072.298c-.08.328-.26 1.04-.296 1.186-.047.19-.154.23-.355.139-1.326-.579-2.155-2.396-2.155-3.857 0-3.14 2.39-6.024 6.89-6.024 3.617 0 6.433 2.461 6.433 5.75 0 3.431-2.256 6.193-5.387 6.193-1.052 0-2.042-.524-2.38-1.145l-.647 2.43c-.234.876-.867 1.973-1.29 2.642.971.291 1.997.45 3.06.45 5.523 0 10-4.02 10-8.98C22 6.02 17.523 2 12 2"/></svg>
+          <span>Share on Pinterest</span>
+        </a>
+      </div>
+    </section>
     <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
       <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
       <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>

--- a/blog/self-awareness-practice.html
+++ b/blog/self-awareness-practice.html
@@ -27,6 +27,12 @@
         blockquote { border-left: 4px solid var(--primary); padding-left: 20px; margin: 30px 0; font-style: italic; color: var(--text-muted); }
         .highlight { background: var(--card-bg); padding: 30px; border-radius: 12px; margin: 30px 0; border: 1px solid var(--border); }
         .highlight h3 { margin-top: 0; }
+        .share-panel { background: var(--card-bg); padding: 24px; border-radius: 12px; margin: 28px 0; border: 1px solid var(--border); }
+        .share-panel h2 { margin: 0 0 10px; }
+        .share-panel p { margin-bottom: 14px; color: var(--text-muted); }
+        .share-actions { display: flex; flex-wrap: wrap; gap: 12px; }
+        .share-button { display: inline-flex; align-items: center; gap: 8px; padding: 11px 16px; border-radius: 999px; text-decoration: none; font-weight: 600; border: 1px solid var(--border); color: var(--text); background: rgba(99, 102, 241, 0.14); }
+        .share-button svg { width: 18px; height: 18px; fill: currentColor; }
         .tags { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 20px; }
         .tag { background: var(--card-bg); padding: 5px 15px; border-radius: 20px; font-size: 0.85rem; color: var(--text-muted); }
         .cta { background: linear-gradient(135deg, var(--primary), var(--secondary)); padding: 40px; border-radius: 16px; text-align: center; margin: 50px 0; }
@@ -123,6 +129,20 @@
                     <li><strong>Quarterly:</strong> Review journal entries for recurring patterns. What triggers consistently produce the same response? Where does your behavior most diverge from your intentions?</li>
                 </ul>
             </div>
+    <section class="share-panel">
+      <h2>Share this article</h2>
+      <p>Share it with someone doing serious inner work or leadership work.</p>
+      <div class="share-actions">
+        <a class="share-button" href="https://twitter.com/intent/tweet?text=Self-Awareness%20Practice%3A%20The%20Skill%20That%20Amplifies%20Every%20Other%20Skill&url=https%3A%2F%2Fmotivational-quote.org%2Fblog%2Fself-awareness-practice.html" target="_blank" rel="noopener noreferrer" aria-label="Share Self-Awareness Practice on Twitter">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.901 1.153h3.68l-8.04 9.19L24 22.847h-7.406l-5.8-7.584-6.633 7.584H.48l8.6-9.83L0 1.153h7.594l5.243 6.932z"/></svg>
+          <span>Share on Twitter</span>
+        </a>
+        <a class="share-button" href="https://www.pinterest.com/pin/create/button/?url=https%3A%2F%2Fmotivational-quote.org%2Fblog%2Fself-awareness-practice.html&description=Self-Awareness%20Practice%3A%20The%20Skill%20That%20Amplifies%20Every%20Other%20Skill" target="_blank" rel="noopener noreferrer" aria-label="Share Self-Awareness Practice on Pinterest">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.477 2 2 6.02 2 10.98c0 3.916 2.813 7.247 6.718 8.42-.093-.714-.177-1.811.037-2.592.194-.707 1.248-4.502 1.248-4.502s-.318-.618-.318-1.532c0-1.435.86-2.506 1.93-2.506.91 0 1.349.652 1.349 1.434 0 .874-.58 2.18-.878 3.39-.249 1.013.53 1.84 1.573 1.84 1.888 0 3.338-1.898 3.338-4.637 0-2.424-1.814-4.12-4.402-4.12-3 0-4.762 2.152-4.762 4.376 0 .867.348 1.796.783 2.301a.31.31 0 0 1 .072.298c-.08.328-.26 1.04-.296 1.186-.047.19-.154.23-.355.139-1.326-.579-2.155-2.396-2.155-3.857 0-3.14 2.39-6.024 6.89-6.024 3.617 0 6.433 2.461 6.433 5.75 0 3.431-2.256 6.193-5.387 6.193-1.052 0-2.042-.524-2.38-1.145l-.647 2.43c-.234.876-.867 1.973-1.29 2.642.971.291 1.997.45 3.06.45 5.523 0 10-4.02 10-8.98C22 6.02 17.523 2 12 2"/></svg>
+          <span>Share on Pinterest</span>
+        </a>
+      </div>
+    </section>
     <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
       <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
       <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>

--- a/blog/stress-management.html
+++ b/blog/stress-management.html
@@ -23,6 +23,12 @@
         li { margin-bottom: 8px; }
         blockquote { border-left: 4px solid var(--primary); padding-left: 20px; margin: 25px 0; font-style: italic; color: var(--text-muted); }
         .highlight { background: var(--card-bg); padding: 25px; border-radius: 12px; margin: 25px 0; border: 1px solid var(--border); }
+        .share-panel { background: var(--card-bg); padding: 24px; border-radius: 12px; margin: 28px 0; border: 1px solid var(--border); }
+        .share-panel h2 { margin: 0 0 10px; }
+        .share-panel p { margin-bottom: 14px; color: var(--text-muted); }
+        .share-actions { display: flex; flex-wrap: wrap; gap: 12px; }
+        .share-button { display: inline-flex; align-items: center; gap: 8px; padding: 11px 16px; border-radius: 999px; text-decoration: none; font-weight: 600; border: 1px solid var(--border); color: var(--text); background: rgba(99, 102, 241, 0.14); }
+        .share-button svg { width: 18px; height: 18px; fill: currentColor; }
         .tags { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 20px; }
         .tag { background: var(--card-bg); padding: 5px 15px; border-radius: 20px; font-size: 0.85rem; color: var(--text-muted); }
         .cta { background: linear-gradient(135deg, var(--primary), var(--secondary)); padding: 35px; border-radius: 16px; text-align: center; margin: 40px 0; }
@@ -72,6 +78,20 @@
 <h2>Quick Wins: Start Today</h2>
 <p>(1) Spend five minutes writing a brief stress audit: list your top three stressors and mark each as controllable, influenceable, or uncontrollable. (2) Schedule your recovery practice tomorrow — even 10 minutes of walking counts. (3) Create a simple end-of-work transition ritual for today: close your laptop, write tomorrow's single top priority, and do two minutes of slow breathing before you move on.</p>
 <div style="background:#4f46e5;color:white;padding:25px;border-radius:12px;text-align:center;margin:25px 0"><a href="/subscribe.html" style="background:white;color:#4f46e5;padding:12px 24px;border-radius:25px;text-decoration:none;font-weight:600;">Subscribe Free</a></div></div>
+    <section class="share-panel">
+      <h2>Share this article</h2>
+      <p>Send it to someone who needs a calmer, more practical way to think about stress.</p>
+      <div class="share-actions">
+        <a class="share-button" href="https://twitter.com/intent/tweet?text=Stress%20Management%3A%20How%20to%20Reduce%2C%20Recover%2C%20and%20Build%20Resilience&url=https%3A%2F%2Fmotivational-quote.org%2Fblog%2Fstress-management.html" target="_blank" rel="noopener noreferrer" aria-label="Share Stress Management on Twitter">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.901 1.153h3.68l-8.04 9.19L24 22.847h-7.406l-5.8-7.584-6.633 7.584H.48l8.6-9.83L0 1.153h7.594l5.243 6.932z"/></svg>
+          <span>Share on Twitter</span>
+        </a>
+        <a class="share-button" href="https://www.pinterest.com/pin/create/button/?url=https%3A%2F%2Fmotivational-quote.org%2Fblog%2Fstress-management.html&description=Stress%20Management%3A%20How%20to%20Reduce%2C%20Recover%2C%20and%20Build%20Resilience" target="_blank" rel="noopener noreferrer" aria-label="Share Stress Management on Pinterest">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.477 2 2 6.02 2 10.98c0 3.916 2.813 7.247 6.718 8.42-.093-.714-.177-1.811.037-2.592.194-.707 1.248-4.502 1.248-4.502s-.318-.618-.318-1.532c0-1.435.86-2.506 1.93-2.506.91 0 1.349.652 1.349 1.434 0 .874-.58 2.18-.878 3.39-.249 1.013.53 1.84 1.573 1.84 1.888 0 3.338-1.898 3.338-4.637 0-2.424-1.814-4.12-4.402-4.12-3 0-4.762 2.152-4.762 4.376 0 .867.348 1.796.783 2.301a.31.31 0 0 1 .072.298c-.08.328-.26 1.04-.296 1.186-.047.19-.154.23-.355.139-1.326-.579-2.155-2.396-2.155-3.857 0-3.14 2.39-6.024 6.89-6.024 3.617 0 6.433 2.461 6.433 5.75 0 3.431-2.256 6.193-5.387 6.193-1.052 0-2.042-.524-2.38-1.145l-.647 2.43c-.234.876-.867 1.973-1.29 2.642.971.291 1.997.45 3.06.45 5.523 0 10-4.02 10-8.98C22 6.02 17.523 2 12 2"/></svg>
+          <span>Share on Pinterest</span>
+        </a>
+      </div>
+    </section>
     <section class="next-step-strip" style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:12px;padding:22px;margin:28px 0;color:#1f2937;">
       <h2 style="margin-top:0;color:#1e3a8a;">Recommended next step</h2>
       <p style="color:#374151;">Turn this idea into a weekly practice with curated resources and one practical prompt at a time.</p>


### PR DESCRIPTION
Closes #109

## Summary
- add a styled share panel to each scoped article
- add Twitter intent links with article-specific titles and canonical URLs
- add Pinterest share links with article-specific descriptions while preserving existing layout

## Verification
- Issue body snapshot at claim: 01fed07f706059ae
- Original queue: agios:escalate-codex
- Ran:   HTML OK
- Confirmed each scoped file contains a share panel plus Twitter and Pinterest share links
