### PR TITLE
Add AdSense readiness checklist and smoke check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 build/
 *.zip
 *.log
+.vercel

--- a/docs/ADSENSE_READINESS.md
+++ b/docs/ADSENSE_READINESS.md
@@ -1,0 +1,34 @@
+# AdSense Readiness Checklist
+
+Use this checklist before requesting or re-requesting AdSense review for motivational-quote.org.
+
+## Required Site Checks
+
+- `https://motivational-quote.org/ads.txt` returns HTTP 200.
+- `ads.txt` contains `google.com, pub-6175161566333696, DIRECT, f08c47fec0942fa0`.
+- `https://motivational-quote.org/sitemap.xml` returns HTTP 200.
+- The sitemap includes `/quote-sources.html`.
+- The homepage links to `quote-sources.html`.
+- Core trust pages are present: `about.html`, `contact.html`, `privacy.html`, `editorial-standards.html`, `quote-sources.html`.
+- Static validation passes.
+- The post-deploy smoke check passes with `node scripts/check-adsense-readiness.mjs`.
+
+## AdSense Console Flow
+
+1. In AdSense, open **Sites**.
+2. Click `motivational-quote.org`.
+3. If `Ads.txt status` is not `Authorized`, click **Check for updates**.
+4. Leave the site in review if AdSense already says `Getting ready`.
+5. If Google returns a concrete issue, patch that issue and rerun the smoke check before requesting review again.
+
+## Vercel Deployment Notes
+
+- Vercel project: `motivational-quote`.
+- Production domain: `motivational-quote.org`.
+- Manual production deploy fallback:
+
+```bash
+npx vercel@latest --prod --yes --token "$VERCEL_TOKEN" --name motivational-quote
+```
+
+Keep Vercel tokens and pulled environment files out of git.

--- a/scripts/check-adsense-readiness.mjs
+++ b/scripts/check-adsense-readiness.mjs
@@ -1,0 +1,81 @@
+import { access, readFile } from 'node:fs/promises';
+
+const BASE_URL = (process.env.BASE_URL || 'https://motivational-quote.org').replace(/\/$/, '');
+const ADS_LINE = 'google.com, pub-6175161566333696, DIRECT, f08c47fec0942fa0';
+
+const requiredFiles = [
+  'ads.txt',
+  'sitemap.xml',
+  'index.html',
+  'about.html',
+  'contact.html',
+  'privacy.html',
+  'editorial-standards.html',
+  'quote-sources.html',
+];
+
+const requiredRoutes = [
+  '/',
+  '/ads.txt',
+  '/sitemap.xml',
+  '/about.html',
+  '/contact.html',
+  '/privacy.html',
+  '/editorial-standards.html',
+  '/quote-sources.html',
+];
+
+async function assertFile(path) {
+  await access(path);
+  console.log(`ok file ${path}`);
+}
+
+async function fetchText(path) {
+  const url = `${BASE_URL}${path}`;
+  const response = await fetch(url, { redirect: 'follow' });
+  if (!response.ok) {
+    throw new Error(`${url} returned HTTP ${response.status}`);
+  }
+  const text = await response.text();
+  console.log(`ok url ${url}`);
+  return text;
+}
+
+async function main() {
+  for (const path of requiredFiles) {
+    await assertFile(path);
+  }
+
+  const adsTxt = await readFile('ads.txt', 'utf8');
+  if (!adsTxt.includes(ADS_LINE)) {
+    throw new Error('ads.txt does not contain the expected AdSense publisher line');
+  }
+  console.log('ok local ads.txt publisher line');
+
+  for (const route of requiredRoutes) {
+    await fetchText(route);
+  }
+
+  const [home, sitemap, liveAdsTxt] = await Promise.all([
+    fetchText('/'),
+    fetchText('/sitemap.xml'),
+    fetchText('/ads.txt'),
+  ]);
+
+  if (!home.includes('quote-sources.html')) {
+    throw new Error('Homepage does not link to quote-sources.html');
+  }
+  if (!sitemap.includes('/quote-sources.html')) {
+    throw new Error('Sitemap does not include /quote-sources.html');
+  }
+  if (!liveAdsTxt.includes(ADS_LINE)) {
+    throw new Error('Live ads.txt does not contain the expected AdSense publisher line');
+  }
+
+  console.log(`AdSense readiness smoke check passed for ${BASE_URL}`);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds a repo-tracked AdSense readiness checklist.
- Adds a production smoke check for ads.txt, sitemap, trust pages, and quote-sources.html.
- Ignores .vercel so pulled deployment settings are not committed.

## Verification
- node scripts/check-adsense-readiness.mjs

Closes #120
