### PR TITLE
seo/content: fix 2 remaining bare-skeleton legacy pages (building-self-discipline, mastering-time-management)

### DIFF
--- a/building-self-discipline.html
+++ b/building-self-discipline.html
@@ -1,1 +1,69 @@
-<html><head><title>Building Self-Discipline</title></head><body><h1>Building Self-Discipline</h1><h2>Understanding Self-Discipline</h2><p>Self-discipline is the ability to regulate one's behavior and make decisions that align with one's values and goals. It is a critical skill for achieving success in both personal and professional life. As the renowned psychologist, Jordan Peterson, once said, <blockquote>&quot;Self-discipline is the ability to do what you should do, even when you don't want to do it.&quot;</blockquote></p><p>To build self-discipline, it is essential to understand the different types of self-discipline that can be developed. These can include self-control, self-motivation, and self-awareness. By categorizing our self-discipline, we can identify areas where we can improve our skills.</p><h2>Strategies for Building Self-Discipline</h2><p>One effective strategy for building self-discipline is to set clear goals and priorities. This can help you stay focused and motivated, and ensure that you are making progress towards your goals. Another strategy is to develop a routine and stick to it. This approach, known as the &quot;habit loop,&quot; can help you build self-discipline and make progress towards your goals.</p><p>Additionally, it is essential to practice self-care and self-compassion. This can involve developing a growth mindset, building a support network, and celebrating progress along the way. As the motivational speaker, Mel Robbins, once said, <blockquote>&quot;You can't build self-discipline if you're not taking care of yourself.&quot;</blockquote></p><p>In addition to these strategies, it is also important to learn to overcome obstacles and stay motivated. This can involve developing a growth mindset, building a support network, and celebrating progress along the way.</p><p>For more information on building self-discipline, check out our articles on <a href="goal-setting.html">goal setting</a> and <a href="daily-motivation.html">daily motivation</a>.</p><p>In conclusion, building self-discipline requires a combination of understanding the different types of self-discipline that can be developed, developing effective strategies, and staying committed. By following these tips and staying focused, you can build self-discipline and achieve your goals. Remember, <blockquote>&quot;Self-discipline is the bridge between goals and accomplishment.&quot; - Jim Rohn</blockquote></p><h2>Practical Advice</h2><p>To get started on building self-discipline, try the following: identify your most important goals, develop a routine, and practice self-care. Celebrate your progress, and use it as motivation to continue building your self-discipline.</p></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Building Self-Discipline – Motivational-Quote.org</title>
+  <meta name="description" content="Practical strategies for building self-discipline through clear goals, consistent routines, and self-care — turning intentions into consistent action." />
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://motivational-quote.org/building-self-discipline.html" />
+  <link rel="stylesheet" href="style.css" />
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6175161566333696" crossorigin="anonymous"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-083MSQKPFX"></script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://motivational-quote.org/" },
+      { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://motivational-quote.org/blog.html" },
+      { "@type": "ListItem", "position": 3, "name": "Building Self-Discipline", "item": "https://motivational-quote.org/building-self-discipline.html" }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <a href="index.html" class="brand">Motivational Quotes</a>
+      <ul class="nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="blog.html">Blog</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="contact.html">Contact</a></li>
+        <li><a href="privacy.html">Privacy Policy</a></li>
+        <li><a href="terms.html">Terms of Use</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main>
+    <section class="content">
+      <h1>Building Self-Discipline</h1>
+
+      <h2>Understanding Self-Discipline</h2>
+      <p>Self-discipline is the ability to regulate one's behavior and make decisions that align with one's values and goals. It is a critical skill for achieving success in both personal and professional life. As the renowned psychologist, Jordan Peterson, once said,</p>
+      <blockquote>&quot;Self-discipline is the ability to do what you should do, even when you don't want to do it.&quot;</blockquote>
+      <p>To build self-discipline, it is essential to understand the different types of self-discipline that can be developed. These can include self-control, self-motivation, and self-awareness. By categorizing our self-discipline, we can identify areas where we can improve our skills.</p>
+
+      <h2>Strategies for Building Self-Discipline</h2>
+      <p>One effective strategy for building self-discipline is to set clear goals and priorities. This can help you stay focused and motivated, and ensure that you are making progress towards your goals. Another strategy is to develop a routine and stick to it. This approach, known as the &quot;habit loop,&quot; can help you build self-discipline and make progress towards your goals.</p>
+      <p>Additionally, it is essential to practice self-care and self-compassion. This can involve developing a growth mindset, building a support network, and celebrating progress along the way. As the motivational speaker, Mel Robbins, once said,</p>
+      <blockquote>&quot;You can't build self-discipline if you're not taking care of yourself.&quot;</blockquote>
+      <p>In addition to these strategies, it is also important to learn to overcome obstacles and stay motivated. This can involve developing a growth mindset, building a support network, and celebrating progress along the way.</p>
+      <p>For more information on building self-discipline, check out our articles on <a href="goal-setting.html">goal setting</a> and <a href="daily-motivation.html">daily motivation</a>.</p>
+      <p>In conclusion, building self-discipline requires a combination of understanding the different types of self-discipline that can be developed, developing effective strategies, and staying committed. By following these tips and staying focused, you can build self-discipline and achieve your goals. Remember,</p>
+      <blockquote>&quot;Self-discipline is the bridge between goals and accomplishment.&quot; - Jim Rohn</blockquote>
+
+      <h2>Practical Advice</h2>
+      <p>To get started on building self-discipline, try the following: identify your most important goals, develop a routine, and practice self-care. Celebrate your progress, and use it as motivation to continue building your self-discipline.</p>
+    </section>
+  </main>
+
+  <footer>
+    <p>&copy; <span id="year"></span> Motivational Quotes. All rights reserved.</p>
+  </footer>
+  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+  <script src="analytics.js"></script>
+</body>
+</html>

--- a/mastering-time-management.html
+++ b/mastering-time-management.html
@@ -1,1 +1,69 @@
-<html><head><title>Mastering Time Management</title></head><body><h1>Mastering Time Management</h1><h2>Understanding Time Management</h2><p>Time management is the process of planning and controlling the amount of time spent on different activities. It is a critical skill for achieving success in both personal and professional life. As the famous time management expert, Stephen Covey, once said, <blockquote>&quot;The key is not to prioritize what's on your schedule, but to schedule your priorities.&quot;</blockquote></p><p>To master time management, it is essential to understand the different types of activities that consume our time. These can include work, leisure, and personal activities. By categorizing our activities, we can identify areas where we can improve our time management.</p><h2>Strategies for Mastering Time Management</h2><p>One effective strategy for mastering time management is to use a calendar or planner. This can help you schedule appointments, meetings, and deadlines, and ensure that you have enough time for each task. Another strategy is to prioritize tasks based on their importance and urgency. This can help you focus on the most critical tasks first and avoid wasting time on non-essential activities.</p><p>Additionally, it is essential to avoid multitasking and minimize distractions. Multitasking can reduce productivity and increase stress, while distractions can derail our focus and reduce our ability to complete tasks. As the productivity expert, Tim Ferriss, once said, <blockquote>&quot;Focus on the most important things first, and then move on to the less important things.&quot;</blockquote></p><p>In addition to these strategies, it is also important to learn to say no to non-essential tasks and commitments. This can help you avoid overcommitting and reduce stress. It is also essential to take breaks and practice self-care, as this can help you recharge and maintain your productivity.</p><p>For more information on mastering time management, check out our articles on <a href="overcoming-procrastination.html">overcoming procrastination</a> and <a href="goal-setting.html">goal setting</a>.</p><p>In conclusion, mastering time management requires a combination of understanding the different types of activities that consume our time, developing effective strategies, and avoiding common pitfalls. By following these tips and staying committed, you can master time management and achieve your goals. Remember, <blockquote>&quot;Time is what we want most, but what we use worst.&quot; - William Penn</blockquote></p><h2>Practical Advice</h2><p>To get started on mastering time management, try the following: identify your most important tasks, schedule them in your calendar, and commit to focusing on them without any distractions. Take regular breaks, and use them to recharge and maintain your productivity.</p></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mastering Time Management – Motivational-Quote.org</title>
+  <meta name="description" content="Practical time-management strategies — prioritizing tasks, avoiding multitasking, and building a distraction-free schedule that protects what matters most." />
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://motivational-quote.org/mastering-time-management.html" />
+  <link rel="stylesheet" href="style.css" />
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6175161566333696" crossorigin="anonymous"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-083MSQKPFX"></script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://motivational-quote.org/" },
+      { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://motivational-quote.org/blog.html" },
+      { "@type": "ListItem", "position": 3, "name": "Mastering Time Management", "item": "https://motivational-quote.org/mastering-time-management.html" }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <a href="index.html" class="brand">Motivational Quotes</a>
+      <ul class="nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="blog.html">Blog</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="contact.html">Contact</a></li>
+        <li><a href="privacy.html">Privacy Policy</a></li>
+        <li><a href="terms.html">Terms of Use</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main>
+    <section class="content">
+      <h1>Mastering Time Management</h1>
+
+      <h2>Understanding Time Management</h2>
+      <p>Time management is the process of planning and controlling the amount of time spent on different activities. It is a critical skill for achieving success in both personal and professional life. As the famous time management expert, Stephen Covey, once said,</p>
+      <blockquote>&quot;The key is not to prioritize what's on your schedule, but to schedule your priorities.&quot;</blockquote>
+      <p>To master time management, it is essential to understand the different types of activities that consume our time. These can include work, leisure, and personal activities. By categorizing our activities, we can identify areas where we can improve our time management.</p>
+
+      <h2>Strategies for Mastering Time Management</h2>
+      <p>One effective strategy for mastering time management is to use a calendar or planner. This can help you schedule appointments, meetings, and deadlines, and ensure that you have enough time for each task. Another strategy is to prioritize tasks based on their importance and urgency. This can help you focus on the most critical tasks first and avoid wasting time on non-essential activities.</p>
+      <p>Additionally, it is essential to avoid multitasking and minimize distractions. Multitasking can reduce productivity and increase stress, while distractions can derail our focus and reduce our ability to complete tasks. As the productivity expert, Tim Ferriss, once said,</p>
+      <blockquote>&quot;Focus on the most important things first, and then move on to the less important things.&quot;</blockquote>
+      <p>In addition to these strategies, it is also important to learn to say no to non-essential tasks and commitments. This can help you avoid overcommitting and reduce stress. It is also essential to take breaks and practice self-care, as this can help you recharge and maintain your productivity.</p>
+      <p>For more information on mastering time management, check out our articles on <a href="overcoming-procrastination.html">overcoming procrastination</a> and <a href="goal-setting.html">goal setting</a>.</p>
+      <p>In conclusion, mastering time management requires a combination of understanding the different types of activities that consume our time, developing effective strategies, and avoiding common pitfalls. By following these tips and staying committed, you can master time management and achieve your goals. Remember,</p>
+      <blockquote>&quot;Time is what we want most, but what we use worst.&quot; - William Penn</blockquote>
+
+      <h2>Practical Advice</h2>
+      <p>To get started on mastering time management, try the following: identify your most important tasks, schedule them in your calendar, and commit to focusing on them without any distractions. Take regular breaks, and use them to recharge and maintain your productivity.</p>
+    </section>
+  </main>
+
+  <footer>
+    <p>&copy; <span id="year"></span> Motivational Quotes. All rights reserved.</p>
+  </footer>
+  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+  <script src="analytics.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Closes #101

## What

Fixes the 2 remaining root-level pages that were served as bare HTML skeletons (no DOCTYPE/meta/canonical/nav/footer, `<blockquote>` illegally nested inside `<p>`) — same defect class as #123 (fixed in PR #122).

- `building-self-discipline.html`
- `mastering-time-management.html`

Each now has: DOCTYPE, charset/viewport, the title/meta-description/canonical text specified in #101, robots meta, stylesheet, AdSense + gtag script tags, and a new BreadcrumbList JSON-LD block (matching #101's spec — these two pages had no JSON-LD at all before, unlike the #123 batch).

## Also added: header/nav + footer

#101's own implementation spec only covered the `<head>` (it assumed body/nav were already fine, matching the older pattern where these pages just needed head fixes). They were not fine — live content had no `<header>`/`<nav>`/`<footer>` at all, same dead-end-page problem as #123. Added the standard site chrome (`<header><nav class="navbar">` with brand + Home/Blog/About/Contact/Privacy Policy/Terms of Use, `<main><section class="content">` wrapping the article, `<footer>` with copyright + year script + analytics.js) to match `art-of-letting-go.html` / the #123 fix.

## Blockquote nesting fix

`<blockquote>` was nested inside `<p>` in 3 places per file (invalid HTML). Fixed by closing the `<p>` right before each `<blockquote>` and making it a sibling block element. No text was added, removed, or reworded — verified by diffing stripped-tag text of the article body (h1/h2/p/blockquote/a content) between old and new: byte-identical.

## Quote attributions — checked, not changed

- `building-self-discipline.html`: quotes attributed to Jordan Peterson and Mel Robbins — no confirming or debunking evidence found (prior triage pass and this pass agree). Left as-is.
- `mastering-time-management.html`: "Time is what we want most, but what we use worst." — William Penn. Searched for Quote Investigator coverage and alternative La Bruyère/Montaigne attribution; found only that Penn is the widely-repeated attribution across quote-aggregator sites (Goodreads, BrainyQuote, AZQuotes) with no scholarly investigation confirming or debunking it, and no solid alternative source. Left as-is — **still unverified either way**.

## Explicitly out of scope

Word-count expansion — both pages stay at their original length, prose unchanged.

## Verification

- [x] `python3 -c "import html.parser..."` (per #101's verification command, extended to also check header/footer presence and blockquote-nesting) passed on both files
- [x] Diffed stripped-tag article text (old vs. new): identical on both files
- [x] Internal links (`goal-setting.html`, `daily-motivation.html`, `overcoming-procrastination.html`) all resolve to existing files
- [ ] Live-URL re-check after deploy (will confirm canonical/DOCTYPE/nav render correctly on the deployed Vercel URL and paste results here)

**Risk level:** LOW (head/nav/footer addition + structural blockquote fix; no body content removed, no template/build changes)
