### PR TITLE
seo/content: fix 6 misattributed/misquoted quotes across 7 blog/ articles

### DIFF
--- a/blog/breaking-bad-habits-for-good.html
+++ b/blog/breaking-bad-habits-for-good.html
@@ -60,7 +60,7 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <p>Willpower operates in the prefrontal cortex, the brain's rational executive. But when a powerful cue fires — stress, boredom, a specific location, a social situation — the basal ganglia engages faster than conscious thought. The habit runs before you have even decided to resist it. This is why sheer determination rarely outlasts a bad day.</p>
 
-    <blockquote>"We are what we repeatedly do. Excellence, then, is not an act, but a habit." — Aristotle</blockquote>
+    <blockquote>"We are what we repeatedly do. Excellence, then, is not an act, but a habit." — Will Durant, summarizing Aristotle's <cite>Nicomachean Ethics</cite> in <cite>The Story of Philosophy</cite> (1926)</blockquote>
 
     <p>The solution is not to fight your brain. It is to reprogram the loop at the level where habits actually live.</p>
 

--- a/blog/flow-habits.html
+++ b/blog/flow-habits.html
@@ -61,7 +61,7 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <h2>The Science of Habit-Flow Interaction</h2>
     <p>Stanford neuroscientist Andrew Huberman's research on dopamine and motivation is particularly relevant here. Dopamine is the currency of flow — it drives pursuit, pleasure in challenge, and the focused engagement that characterizes optimal experience. Habits that spike dopamine artificially (checking social media, excessive sugar, pornography) downregulate the dopamine system over time, making it harder to feel the natural reward of deep, meaningful work. Habits that produce gentle, sustained dopamine — exercise, mastery practice, social connection, accomplishment — upregulate sensitivity and make flow more accessible.</p>
-    <blockquote>"We are what we repeatedly do. Excellence, then, is not an act but a habit." — Aristotle</blockquote>
+    <blockquote>"We are what we repeatedly do. Excellence, then, is not an act but a habit." — Will Durant, summarizing Aristotle's <cite>Nicomachean Ethics</cite> in <cite>The Story of Philosophy</cite> (1926)</blockquote>
     <p>Aristotle was gesturing at something neuroscience has since confirmed: repeated behaviors literally reshape neural circuitry. The habits you practice daily don't just fill your time — they physically wire your brain for certain states. Build the right habits consistently and flow becomes the default state during focused work, not the rare exception.</p>
 
     <h2>The Seven Habits That Create Flow-Ready Days</h2>

--- a/blog/how-to-set-and-achieve-goals.html
+++ b/blog/how-to-set-and-achieve-goals.html
@@ -77,7 +77,7 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <p>The reason is that when the situation arrives — Friday evening, leaving work — your plan fires automatically rather than requiring an in-the-moment decision under competing temptations. You've pre-committed the decision at a time when you were clear-headed and motivated.</p>
 
-    <blockquote>"A goal without a plan is just a wish." — Antoine de Saint-Exupéry</blockquote>
+    <blockquote>"A goal without a plan is just a wish." — a popular saying often attributed to Antoine de Saint-Exupéry, though it does not appear in his writings</blockquote>
 
     <h2>Mental Contrasting: The Power of If-Then Obstacles</h2>
 

--- a/blog/narrative-identity.html
+++ b/blog/narrative-identity.html
@@ -89,7 +89,7 @@
 
             <p>The <em>impostor narrative</em> is the story that your successes are contingent and external while your failures are essential and revealing. It generates a systematic asymmetry in how evidence is weighted: the same person who dismisses genuine achievements as luck, timing, or the failure of others to notice the truth will accept setbacks as confirmation of a deep personal inadequacy. This narrative does not produce humility; it produces a kind of chronic self-undermining that, over time, limits the range of opportunities a person is willing to pursue.</p>
 
-            <blockquote>"We are the stories we tell ourselves." &mdash; Joan Didion</blockquote>
+            <blockquote>"We tell ourselves stories in order to live." &mdash; Joan Didion, <cite>The White Album</cite> (1979)</blockquote>
 
             <h2>How to Audit Your Own Narrative</h2>
 

--- a/blog/why-comparison-is-the-thief-of-joy.html
+++ b/blog/why-comparison-is-the-thief-of-joy.html
@@ -52,11 +52,11 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <p>You're making real progress. You've put in the work, developed your skills, and built something you're genuinely proud of. Then you scroll through social media for three minutes and suddenly feel like you're behind, inadequate, maybe even failing. Nothing about your actual situation changed. But you feel worse.</p>
 
-    <p>This is what Theodore Roosevelt meant when he said comparison is the thief of joy — and he said it before the internet existed. In a world of curated highlight reels, algorithmic feeds designed to surface aspirational content, and metrics that make other people's success instantly visible, the thief has never been better armed.</p>
+    <p>The line is often credited to Theodore Roosevelt, though no confirmed original source has ever been found. Whoever said it first, the sentiment predates the internet by decades. In a world of curated highlight reels, algorithmic feeds designed to surface aspirational content, and metrics that make other people's success instantly visible, the thief has never been better armed.</p>
 
     <p>Understanding why comparison feels so compelling — and so corrosive — is the first step to disarming it. The second step is learning to measure yourself against the only benchmark that actually has anything to do with your life.</p>
 
-    <blockquote>"Comparison is the thief of joy." — Theodore Roosevelt</blockquote>
+    <blockquote>"Comparison is the thief of joy." — often attributed to Theodore Roosevelt, though no confirmed original source has been found</blockquote>
 
     <h2>Why Our Brains Are Wired to Compare</h2>
 

--- a/blog/why-discipline-beats-motivation.html
+++ b/blog/why-discipline-beats-motivation.html
@@ -62,7 +62,7 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
 
     <p>This is why the advice "just get started" is not a platitude — it's neuroscience. The brain's dopamine system is triggered by progress, not by intention. Once you begin a task, your brain starts rewarding you for continuing it. But you have to make the first move. Discipline is what gets you to that first move when motivation is absent.</p>
 
-    <blockquote>"We are what we repeatedly do. Excellence, then, is not an act, but a habit." — Aristotle</blockquote>
+    <blockquote>"We are what we repeatedly do. Excellence, then, is not an act, but a habit." — Will Durant, summarizing Aristotle's <cite>Nicomachean Ethics</cite> in <cite>The Story of Philosophy</cite> (1926)</blockquote>
 
     <p>Aristotle understood this 2,400 years ago. The person who exercises every morning isn't more motivated than you — they've simply made the decision non-negotiable. The alarm goes off, the shoes go on. There's no internal debate, no checking in with their feelings. The question "do I feel like it?" has been permanently retired.</p>
 

--- a/blog/zen-habits.html
+++ b/blog/zen-habits.html
@@ -62,7 +62,7 @@ nav a{color:#4f46e5;text-decoration:none;font-size:0.9rem}
     <h2>Why Most Habits Fail — and What the Research Says</h2>
     <p>Behavioral research by Wendy Wood at USC found that roughly 43% of our daily behaviors are habits — automatic responses to contextual cues rather than deliberate choices. This is crucial: lasting behavioral change isn't about making better decisions repeatedly; it's about building better automatic behaviors. The habit loop (cue → routine → reward, as described by Charles Duhigg) isn't a motivational framework — it's a description of how the basal ganglia stores and retrieves behavioral patterns automatically.</p>
 
-    <blockquote>"Simplicity is the ultimate sophistication." — Leonardo da Vinci</blockquote>
+    <blockquote>"Simplicity is the ultimate sophistication." — often attributed to Leonardo da Vinci, though no confirmed original source has been found</blockquote>
 
     <p>The Zen approach intuitively grasps what the research confirms: complexity kills habits. Every additional step, every decision required, every environment that isn't designed to support the behavior creates friction that accumulates into abandonment. Zen habits strip habits to their simplest possible form, removing as much friction as physically possible, and rely on the automaticity of the habit loop rather than ongoing motivation.</p>
 


### PR DESCRIPTION
Closes #129

## What

Fixes 6 distinct misattributed/misquoted quotes across 7 files in `blog/`, per this site's own `quote-sources.html` policy ("avoid disputed authorship unless the uncertainty is explained"). This is the `blog/` follow-up to the earlier root-level triage (PR #122, #126) — that pass explicitly excluded `blog/`'s 242 articles as out of scope.

1. **`blog/why-comparison-is-the-thief-of-joy.html`** — "Comparison is the thief of joy." was attributed flatly to Theodore Roosevelt, both in the blockquote and asserted as fact in body text. Quote Investigator (quoteinvestigator.com/2021/02/06/thief-of-joy/) found no evidence in any Roosevelt speech or writing. Changed blockquote to "— often attributed to Theodore Roosevelt, though no confirmed original source has been found" (same phrasing as the existing Roosevelt fix on `overcoming-procrastination.html`) and rewrote the body sentence to stop asserting it as settled fact.
2. **`blog/zen-habits.html`** — "Simplicity is the ultimate sophistication." attributed to Leonardo da Vinci. Quote Investigator and Check Your Fact both find no evidence in da Vinci's writings; earliest traced source is a 1931 Clare Boothe Luce novel, only attached to da Vinci's name from ~2000. Changed to the same "often attributed to... though no confirmed original source has been found" framing.
3. **`blog/narrative-identity.html`** — blockquote read `"We are the stories we tell ourselves." — Joan Didion`, a garbled popular misquote. Didion's actual line, from *The White Album* (1979), is "We tell ourselves stories in order to live." Replaced with the accurate quote and a proper citation.
4. **`blog/how-to-set-and-achieve-goals.html`** — "A goal without a plan is just a wish." attributed to Antoine de Saint-Exupéry. Per Wikiquote's sourced research this circulated anonymously (earliest trace: a 1995 book) and was only attached to his name around 2007. Changed to hedged framing.
5. **`blog/breaking-bad-habits-for-good.html`, `blog/flow-habits.html`, `blog/why-discipline-beats-motivation.html`** — all three attributed "We are what we repeatedly do... not an act but a habit" flatly to Aristotle. This is the exact known issue already fixed on `overcoming-procrastination.html` (Will Durant's 1926 paraphrase in *The Story of Philosophy*, not a verbatim Aristotle line — `blog/daily-mastery.html` already had this right). Corrected all 3 to the identical Durant/Aristotle phrasing used on the root page, preserving each file's original quote wording/punctuation untouched.

## Audit scope

Extracted and deduped every `<blockquote>` across all 242 `blog/*.html` files (155 carried some form of attribution; the other 73 are unattributed pull-quote-style summaries with no author claim, out of scope). That yielded 121 distinct quote+author pairs. The 6 above were confirmed misattributed/misquoted via Quote Investigator, Check Your Fact, or Wikiquote. A handful of others were checked and found inconclusive (no fact-check source either way) and were deliberately left alone rather than guessed at: "First we make our habits, then our habits make us" — Charles C. Noble; "An investment in knowledge pays the best interest" — Benjamin Franklin; "Knowing yourself is the beginning of all wisdom" — Aristotle; "The effective executive does not squeeze days..." — Peter Drucker. The remaining ~110 distinct attributions are well-documented/undisputed (Marcus Aurelius, Viktor Frankl, Cal Newport, James Clear, etc.) or already carry the site's own hedged framing (e.g. "widely attributed to Darwin," "paraphrasing Warren Buffett," "adapted from Tim Ferriss," "Attributed to the Buddha") and were left untouched.

## Explicitly not touched

`blog/daily-mastery.html`'s existing "Will Durant (paraphrasing Aristotle)" framing — already honest/compliant, just slightly different wording than the canonical phrase, not worth touching for a wording-only alignment. No other blockquote in any of the 242 files was modified.

## Verification

- [x] `python3 -c "import html.parser..."` (per issue #129's verification command) passed on all 7 files
- [x] `git diff --stat` shows exactly 7 files changed, 8 lines changed total (1 extra line in `why-comparison-is-the-thief-of-joy.html` for the body-text sentence) — no other content touched
- [x] Will deploy to production and curl the 7 live pages after merge to confirm

**Risk level:** LOW (citation-text-only changes across 7 pages; no structural/template changes; CI's link-checker only scans root-level HTML so is unaffected either way)
