### PR TITLE
infra-verify: throwaway fail-closed scope test (expect FAIL)

### DIFF
--- a/infra-verify-out-of-scope.txt
+++ b/infra-verify-out-of-scope.txt
@@ -1,0 +1,1 @@
+out-of-scope test file - should NOT be allowed by issue #135


### PR DESCRIPTION
Closes #135

Throwaway PR that deliberately touches `infra-verify-out-of-scope.txt`, which is NOT in issue #135's Allowed paths (`infra-verify-marker2.txt`). Issue #135 uses the legacy fenced-code-block format. Before the check_scope.py fix, this PR would have incorrectly PASSED the scope check (empty parsed allowlist = fail open). Expecting "Issue-level scope enforcement" to now FAIL. Will close this PR without merging once confirmed, and clean up.

**Risk level:** LOW
