### PR TITLE
infra: fix auto-merge issue-close for real this time (inline poll, not a second job)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,8 +4,6 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
-  pull_request:
-    types: [closed]
 
 permissions:
   contents: write
@@ -16,13 +14,13 @@ jobs:
   policy-gate:
     name: Policy-gated auto-merge
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO: ${{ github.repository }}
       RUN_ID: ${{ github.event.workflow_run.id }}
     steps:
-      - name: Check gates and enable auto-merge
+      - name: Check gates, enable auto-merge, and close the linked issue
         run: |
           # Get PR number from the workflow run
           PR=$(gh api "repos/$REPO/actions/runs/$RUN_ID" \
@@ -70,35 +68,36 @@ jobs:
             --auto \
             --squash
 
-  close-linked-issue:
-    name: Close linked issue on merge
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true }}
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      REPO: ${{ github.repository }}
-      PR: ${{ github.event.pull_request.number }}
-    steps:
-      - name: Explicitly close the linked issue
-        run: |
-          # GitHub's implicit "Closes #N" auto-close-on-merge is unreliable for
-          # PRs merged via `gh pr merge --auto` under GITHUB_TOKEN, even with
-          # issues: write granted (confirmed empirically: a throwaway PR with
-          # "Closes #N" in its body merged cleanly via auto-merge but left the
-          # issue open, while the same merge performed by a full-scope PAT
-          # closed it instantly). Rather than depend on that platform behavior,
-          # close explicitly here, triggered by the PR actually merging,
-          # regardless of who/what performed the merge.
-          PR_BODY=$(gh pr view "$PR" --repo "$REPO" --json body --jq '.body')
-          ISSUE=$(echo "$PR_BODY" | grep -ioE "closes?\s+#[0-9]+" | grep -oE "[0-9]+" | head -1)
+          # GitHub's implicit "Closes #N" auto-close-on-merge is unreliable
+          # for PRs merged via `gh pr merge --auto` under GITHUB_TOKEN, even
+          # with issues: write granted (confirmed empirically: a throwaway
+          # PR merged cleanly this way but left its linked issue open, while
+          # an identical merge performed directly with a full-scope PAT
+          # closed it instantly). A separate job listening for
+          # `pull_request: closed` doesn't fix this either — GitHub Actions
+          # does not trigger new workflow runs from events caused by the
+          # default GITHUB_TOKEN, so that event never arrives. Instead,
+          # poll for the merge to land within *this* run (whose own trigger
+          # is workflow_run, not GITHUB_TOKEN-caused, so it isn't subject to
+          # that suppression) and close the issue explicitly once it does.
+          echo "Waiting for PR #$PR to merge..."
+          MERGED="false"
+          for i in $(seq 1 24); do
+            MERGED=$(gh pr view "$PR" --repo "$REPO" --json merged --jq '.merged')
+            if [ "$MERGED" = "true" ]; then
+              echo "PR #$PR merged."
+              break
+            fi
+            sleep 5
+          done
 
-          if [ -z "$ISSUE" ]; then
-            echo "No 'Closes #N' in PR #$PR body — nothing to close"
+          if [ "$MERGED" != "true" ]; then
+            echo "PR #$PR has not merged after ~2 minutes of polling — leaving issue #$ISSUE open for now (backlog hygiene sweep will catch it if it merges later)"
             exit 0
           fi
 
-          STATE=$(gh issue view "$ISSUE" --repo "$REPO" --json state --jq '.state' 2>/dev/null)
-          if [ "$STATE" = "CLOSED" ]; then
+          ISSUE_STATE=$(gh issue view "$ISSUE" --repo "$REPO" --json state --jq '.state' 2>/dev/null)
+          if [ "$ISSUE_STATE" = "CLOSED" ]; then
             echo "Issue #$ISSUE already closed — nothing to do"
             exit 0
           fi


### PR DESCRIPTION
## What

Replaces the separate `pull_request: closed`-triggered job (added in the previous PR) with an inline poll-and-close inside the existing `policy-gate` job.

## Why (the previous fix didn't work either — verified live)

Re-tested after merging the "add explicit close-linked-issue job" PR: a fresh throwaway issue+PR pair merged cleanly through `auto-merge.yml`, but the new `pull_request: closed`-triggered job never ran at all. Root cause: **GitHub Actions does not start new workflow runs from events caused by the default `GITHUB_TOKEN`** (this is a documented anti-recursion protection). Since the merge is performed by `gh pr merge --auto` using `secrets.GITHUB_TOKEN`, the resulting `pull_request: closed` event is attributed to that token and never triggers the second job — confirmed by checking the Actions run history immediately after the test PR merged: no new run appears for it, ever (waited >1 minute).

## Fix

Moved the close logic inline, into the same `policy-gate` job that's already running (triggered by `workflow_run` on the `CI` workflow completing — a trigger that originates from a real push/PR-open action, not from `GITHUB_TOKEN`, so it isn't subject to the suppression). After enabling auto-merge, the job now polls `gh pr view --json merged` every 5s for up to 2 minutes, and once the PR shows merged, explicitly closes the linked issue via `gh issue close`. If the PR hasn't merged within that window, the job exits without closing anything (safe — no false-positive closes); the periodic backlog-hygiene sweep is the net for that edge case.

Removes the `pull_request: types: [closed]` trigger and the now-dead `close-linked-issue` job from the previous PR — they never fire, so keeping them would just be misleading dead code.

## Scope

Touches only `.github/workflows/auto-merge.yml` (trusted infra path) — no linked issue needed.

## Verification

Will re-run the same throwaway issue+PR test a third time and confirm the issue closes within ~2 minutes of merge, this time actually observing the `policy-gate` job's own log output for the close step (not just inferring from a separate run that never appears).

**Risk level:** LOW (same job, same trigger; adds a bounded poll loop and an explicit close call after the existing merge call)
