### PR TITLE
infra-verify: remove throwaway test marker files

### DIFF
--- a/infra-verify-marker.txt
+++ b/infra-verify-marker.txt
@@ -1,1 +1,0 @@
-infra verification marker - created 2026-07-13T03:45:34Z - safe to delete, see issue #133 / PR

--- a/infra-verify-marker3.txt
+++ b/infra-verify-marker3.txt
@@ -1,1 +1,0 @@
-Isolation test: does a direct merge via my own full-scope PAT close the issue?

--- a/infra-verify-marker4.txt
+++ b/infra-verify-marker4.txt
@@ -1,1 +1,0 @@
-retest marker

--- a/infra-verify-marker5.txt
+++ b/infra-verify-marker5.txt
@@ -1,1 +1,0 @@
-retest2 marker

--- a/infra-verify-marker6.txt
+++ b/infra-verify-marker6.txt
@@ -1,1 +1,0 @@
-retest3 marker


### PR DESCRIPTION
Closes #148

Removes the 5 throwaway marker files used to verify the deploy + auto-merge fixes.
