### PR TITLE
Resolve clean trust page URLs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "cleanUrls": true,
+  "rewrites": [
+    {
+      "source": "/editorial-policy",
+      "destination": "/editorial-standards.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add Vercel clean URL routing so static trust pages resolve at extensionless AdSense-review URLs.
- Rewrite /editorial-policy to the existing editorial standards page.

## Files changed
- vercel.json

## Verification
- python3 -c "import json; json.load(open('vercel.json')); print('vercel config ok')"

## Handoff
- Live audit showed /about, /contact, /privacy, /terms, and /editorial-policy returned 404 while their .html equivalents returned 200.
- This preserves existing page content and changes only routing.

Closes #151
