### PR TITLE
Add editorial policy clean URL alias

### DIFF
--- a/editorial-policy.html
+++ b/editorial-policy.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Editorial Standards – Motivational-Quote.org</title>
+  <meta name="description" content="How Motivational-Quote.org selects quotes, researches personal growth articles, handles affiliate links, and updates content." />
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://motivational-quote.org/editorial-standards.html" />
+  <link rel="stylesheet" href="style.css" />
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-083MSQKPFX"></script>
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <a href="index.html" class="brand">Motivational Quotes</a>
+      <ul class="nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="blog.html">Blog</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="editorial-standards.html">Editorial Standards</a></li>
+        <li><a href="contact.html">Contact</a></li>
+        <li><a href="privacy.html">Privacy Policy</a></li>
+        <li><a href="terms.html">Terms of Use</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main>
+    <section class="content topic-hub">
+      <p class="eyebrow">Trust and transparency</p>
+      <h1>Editorial Standards</h1>
+      <p>
+        Motivational-Quote.org exists to make useful personal-growth ideas easier to find, reflect on, and apply. We publish quote collections, reflection prompts, and practical articles on motivation, resilience, habits, focus, and wellbeing.
+      </p>
+
+      <h2>Quote Selection</h2>
+      <p>
+        We prioritize clearly attributed quotes from public-domain or otherwise reputable sources. If authorship is uncertain, we either avoid the quote or describe the uncertainty rather than presenting it as fact.
+      </p>
+
+      <h2>Article Research</h2>
+      <p>
+        Our articles are written to give readers a useful next step, not just a list of inspirational statements. When we discuss psychology, habits, or productivity research, we aim to represent the idea plainly and avoid overstating what a study proves.
+      </p>
+
+      <h2>Advertising and Affiliate Links</h2>
+      <p>
+        This site may earn revenue from Google AdSense, newsletter sponsorships, and affiliate links to books, mindfulness tools, or productivity resources. Monetization does not determine whether a quote or article is included. Sponsored or affiliate links are labeled through standard link attributes and disclosures where relevant.
+      </p>
+
+      <h2>Corrections</h2>
+      <p>
+        If you find a misattributed quote, broken link, factual issue, or article that needs more depth, please contact us. We would rather correct a page than keep weak information online.
+      </p>
+
+      <h2>Content Updates</h2>
+      <p>
+        We periodically refresh article introductions, internal links, category pages, and quote
+        attributions so readers and search engines can understand which pages are current, useful,
+        and connected to the rest of the site.
+      </p>
+    </section>
+  </main>
+
+  <footer>
+    <p>&copy; <span id="year"></span> Motivational Quotes. All rights reserved.</p>
+  </footer>
+  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+  <script src="analytics.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add editorial-policy.html as a static alias for the existing editorial standards content so /editorial-policy works with Vercel cleanUrls.

## Files changed
- editorial-policy.html

## Verification
- test -f editorial-policy.html

## Handoff
- Previous routing PR fixed /about, /contact, /privacy, and /terms.
- Live smoke test still showed /editorial-policy returning 404, so this adds a deterministic static alias.

Closes #153
