### PR TITLE
Fix MQ clean URL consolidation redirect

### DIFF
--- a/scripts/apply_url_decisions.py
+++ b/scripts/apply_url_decisions.py
@@ -205,7 +205,7 @@ def write_sitemap(retained: list[str]) -> None:
 
 
 def write_vercel() -> None:
-    config = {"cleanUrls": True, "redirects": [{"source": "/blog/overcoming-procrastination.html", "destination": "/overcoming-procrastination.html", "permanent": True}], "rewrites": [{"source": "/editorial-policy", "destination": "/editorial-standards.html"}]}
+    config = {"cleanUrls": True, "redirects": [{"source": "/blog/overcoming-procrastination", "destination": "/overcoming-procrastination", "permanent": True}], "rewrites": [{"source": "/editorial-policy", "destination": "/editorial-standards.html"}]}
     (ROOT / "vercel.json").write_text(json.dumps(config, indent=2) + "\n")
 
 

--- a/scripts/verify_production_urls.py
+++ b/scripts/verify_production_urls.py
@@ -116,7 +116,7 @@ def main() -> None:
 
     config = json.loads((ROOT / "vercel.json").read_text())
     redirects = config.get("redirects", [])
-    expected_redirect = {"source": "/blog/overcoming-procrastination.html", "destination": "/overcoming-procrastination.html", "permanent": True}
+    expected_redirect = {"source": "/blog/overcoming-procrastination", "destination": "/overcoming-procrastination", "permanent": True}
     if redirects != [expected_redirect]:
         fail(f"redirect policy must contain only the approved duplicate: {redirects}")
 

--- a/vercel.json
+++ b/vercel.json
@@ -2,8 +2,8 @@
   "cleanUrls": true,
   "redirects": [
     {
-      "source": "/blog/overcoming-procrastination.html",
-      "destination": "/overcoming-procrastination.html",
+      "source": "/blog/overcoming-procrastination",
+      "destination": "/overcoming-procrastination",
       "permanent": true
     }
   ],


### PR DESCRIPTION
Closes #159

## Summary

Fixes the one production edge case discovered after #160: Vercel applies `cleanUrls` before custom redirects, so the approved duplicate article was being normalized to an extensionless 404. The redirect source and destination now match Vercel's extensionless routing.

## Files changed

- Updated the single approved redirect in `vercel.json`.
- Updated the deterministic generator and production verifier to enforce the corrected route.

## Verification

- `python3 scripts/verify_production_urls.py` — passes.
- `git diff --check` — passes.
- Pre-fix live audit: 31 retained URLs return 200, 258 removals return 404, and only the approved consolidation redirect failed.

## Issue type

MAINTENANCE
